### PR TITLE
Implemented LimitsInputProducer

### DIFF
--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -1,10 +1,11 @@
 [ANA_DESC common]
 int_lumi: 35900
-final_variable: m_sv
-final_variable: m_kinFit
-final_variable: mt2
+final_variables: m_ttbb_kinfit MT2
 apply_mass_cut: true
 energy_scales: all
+limit_category: 2jets0btag res0b
+limit_category: 2jets1btag res1b
+limit_category: 2jets2btag res2b
 
 [ANA_DESC full : common]
 signals: Signal_Radion Signal_Graviton Signal_SM
@@ -12,6 +13,13 @@ backgrounds: TT DY Wjets WW WZ ZZ ZH EWK tW QCD
 data: Data_SingleElectron Data_SingleMuon Data_Tau
 cmb_samples: DY_cmb other_bkg
 draw_sequence: Signal_Radion Signal_SM ZH other_bkg DY_cmb QCD TT data
+
+[ANA_DESC reduced : common]
+signals: Signal_Radion Signal_SM
+backgrounds: DY QCD
+data: Data_SingleElectron Data_SingleMuon Data_Tau
+cmb_samples: DY_cmb
+draw_sequence: Signal_Radion Signal_SM DY_cmb QCD data
 
 [DY]
 file_path: DYJetsToLL_M-50.root
@@ -88,7 +96,7 @@ draw_ex: M600 kBlue
 draw_sf: 5
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: hh_bbtt_Radion_M{M}
+datacard_name: ggRadion_hh_ttbb_M{M}
 
 [Signal_Graviton]
 name_suffix: M{M}
@@ -99,7 +107,7 @@ draw_ex: M250 kGreen
 draw_ex: M600 kBlue
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: hh_bbtt_Graviton_{M}
+datacard_name: ggGraviton_hh_ttbb_M{M}
 
 [Signal_SM]
 file_path: ggHH_SM.root
@@ -110,28 +118,28 @@ title: {factor} SM HH#rightarrowbb#tau#tau
 color: kBlack
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: Signal_SM
+datacard_name: ggh_hh_ttbb_kl0
 
 [Data_SingleElectron]
 file_path: SingleElectron_2016.root
 title: Data_eTau
 channels: eTau
 sample_type: Data
-datacard_name: Data
+datacard_name: data_obs
 
 [Data_SingleMuon]
 file_path: SingleMuon_2016.root
 title: Data_muTau
 channels: muTau
 sample_type: Data
-datacard_name: Data
+datacard_name: data_obs
 
 [Data_Tau]
 file_path: Tau_2016.root
 title: Data_tauTau
 channels: tauTau
 sample_type: Data
-datacard_name: Data
+datacard_name: data_obs
 
 [QCD]
 title: QCD

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -10,7 +10,7 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 #include "h-tautau/Cuts/include/hh_bbtautau_2016.h"
 #include "h-tautau/Analysis/include/EventLoader.h"
 #include "StackedPlotsProducer.h"
-
+#include "LimitsInputProducer.h"
 
 namespace analysis {
 
@@ -146,6 +146,17 @@ public:
         ProcessSamples(ana_setup.backgrounds, "background");
         ProcessCombinedSamples(ana_setup.cmb_samples);
 
+        std::cout << "Producing inputs for limits..." << std::endl;
+        LimitsInputProducer<FirstLeg, SecondLeg> limitsInputProducer(anaDataCollection, sample_descriptors,
+                                                                     cmb_sample_descriptors);
+        for(const std::string& hist_name : ana_setup.final_variables) {
+            for(const auto& subCategory : EventSubCategoriesToProcess()) {
+                std::cout << '\t' << hist_name << "/" << subCategory << std::endl;
+                limitsInputProducer.Produce(args.output(), hist_name, ana_setup.limit_categories, subCategory,
+                                            ana_setup.energy_scales);
+            }
+        }
+
         if(args.draw()) {
             std::cout << "Creating plots..." << std::endl;
             const auto samplesToDraw = PlotsProducer::CreateOrderedSampleCollection(
@@ -172,7 +183,7 @@ protected:
                 throw exception("Sample '%1%' not found.") % sample_name;
             SampleDescriptor& sample = sample_descriptors.at(sample_name);
             if(sample.channels.size() && !sample.channels.count(ChannelId())) continue;
-            std::cout << sample.name << std::endl;
+            std::cout << '\t' << sample.name << std::endl;
             sample.CreateWorkingPoints();
             if(sample.sampleType == SampleType::QCD) {
                 if(sample_index != sample_names.size() - 1)
@@ -219,7 +230,7 @@ protected:
                     const EventAnalyzerDataId anaDataId(eventCategory, subCategory, eventRegion,
                                                         event.GetEnergyScale(), sample_wp.full_name);
                     if(sample.sampleType == SampleType::Data) {
-                        anaDataCollection.Fill(anaDataId, event, 1);
+                        ProcessDataEvent(anaDataId, event);
                     } else {
                         const double weight = event->weight_total * sample.cross_section * ana_setup.int_lumi
                                             / summary->totalShapeWeight;
@@ -236,6 +247,13 @@ protected:
     virtual void EstimateQCD(const SampleDescriptor& /*qcd_sample*/)
     {
         // TODO: implement QCD estimation.
+    }
+
+    void ProcessDataEvent(const EventAnalyzerDataId& anaDataId, EventInfo& event)
+    {
+        for(const auto& es : ana_setup.energy_scales) {
+            anaDataCollection.Fill(anaDataId.Set<EventEnergyScale>(es), event, 1);
+        }
     }
 
     virtual void ProcessSpecialEvent(const SampleDescriptor& sample, const SampleDescriptor::Point& /*sample_wp*/,
@@ -291,30 +309,24 @@ protected:
 
     void AddSampleToCombined(CombinedSampleDescriptor& sample, SampleDescriptor& sub_sample)
     {
-        for(const auto& energyScale : ana_setup.energy_scales) {
-            for(const auto& category : EventCategoriesToProcess()) {
-                for(const auto& subCategory : EventSubCategoriesToProcess()) {
-                    for(const auto& region : EventRegionsToProcess()) {
-                        const EventAnalyzerDataId metaDataId(category, subCategory, region, energyScale);
-                        const auto anaDataId = metaDataId.Set(sample.name);
-                        auto& anaData = anaDataCollection.Get(anaDataId);
-                        for(const auto& sub_sample_wp : sub_sample.working_points) {
-                            const auto subDataId = metaDataId.Set(sub_sample_wp.full_name);
-                            auto& subAnaData = anaDataCollection.Get(subDataId);
-                            for(const auto& sub_entry_base : subAnaData.GetEntries()) {
-                                auto sub_entry = dynamic_cast<root_ext::AnalyzerDataEntry<TH1D>*>(
-                                            sub_entry_base.second);
-                                if(!sub_entry) continue;
-                                auto entry = dynamic_cast<root_ext::AnalyzerDataEntry<TH1D>*>(
-                                            anaData.GetEntries().at(sub_entry_base.first));
-                                if(!entry)
-                                    throw exception("Unable to get entry '%1%' for combined sample '%2%'.")
-                                        % sub_entry_base.first % sample.name;
-                                for(const auto& hist : sub_entry->GetHistograms()) {
-                                    (*entry)(hist.first).Add(hist.second.get(), 1);
-                                }
-                            }
-                        }
+        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
+                EventSubCategoriesToProcess(), EventRegionsToProcess(), ana_setup.energy_scales)) {
+            const auto anaDataId = metaDataId.Set(sample.name);
+            auto& anaData = anaDataCollection.Get(anaDataId);
+            for(const auto& sub_sample_wp : sub_sample.working_points) {
+                const auto subDataId = metaDataId.Set(sub_sample_wp.full_name);
+                auto& subAnaData = anaDataCollection.Get(subDataId);
+                for(const auto& sub_entry_base : subAnaData.GetEntries()) {
+                    auto sub_entry = dynamic_cast<root_ext::AnalyzerDataEntry<TH1D>*>(
+                                sub_entry_base.second);
+                    if(!sub_entry) continue;
+                    auto entry = dynamic_cast<root_ext::AnalyzerDataEntry<TH1D>*>(
+                                anaData.GetEntries().at(sub_entry_base.first));
+                    if(!entry)
+                        throw exception("Unable to get entry '%1%' for combined sample '%2%'.")
+                            % sub_entry_base.first % sample.name;
+                    for(const auto& hist : sub_entry->GetHistograms()) {
+                        (*entry)(hist.first).Add(hist.second.get(), 1);
                     }
                 }
             }

--- a/Analysis/include/EventAnalyzerData.h
+++ b/Analysis/include/EventAnalyzerData.h
@@ -15,11 +15,14 @@ public:
     const bool SaveAll = true;
 
     const BinVector M_tt_Bins = { 10, 35, 60, 85, 110, 135, 160, 185, 210, 250, 300, 350, 400, 500 };
-    const BinVector M_ttbb_Bins = { 260, 300, 350, 400, 450, 500, 600, 700, 850, 1000 };
+    const BinVector M_ttbb_Bins = { 250, 260, 270, 280, 290, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550,
+                                    600, 650, 700, 850, 1000 };
+    const BinVector MT2_Bins = { 0, 25, 50, 75, 100, 125, 150, 175, 200, 250, 300, 500 };
 
     TH1D_ENTRY_CUSTOM_EX(m_ttbb, M_ttbb_Bins, "M_{#tau#tau+jj} (GeV)", "dN/dm_{#tau#tau+jj} (1/GeV)", false, 1.5, true, SaveAll)
     TH1D_ENTRY_CUSTOM_EX(m_ttbb_kinfit, M_ttbb_Bins, "M_{H}^{kinfit} (GeV)", "dN/dm_{H}^{kinfit} (1/GeV)", false, 1.4, true, true)
     TH1D_ENTRY_CUSTOM_EX(m_sv, M_tt_Bins, "M_{#tau#tau} (GeV)", "dN/dm_{#tau#tau} (1/GeV)", false, 1.3, true, true)
+    TH1D_ENTRY_CUSTOM_EX(MT2, MT2_Bins, "MT2_{H} (GeV)", "dN/dm (1/GeV)", false, 1.4, true, true)
 
     TH1D_ENTRY_CUSTOM_EX(m_tt_vis, M_tt_Bins, "M_{vis}(GeV)", "Events", false, 1.1, false, SaveAll)
     TH1D_ENTRY_EX(pt_H_tt, 20, 0, 300, "P_{T}(GeV)", "Events", false, 1.2, false, SaveAll)
@@ -59,6 +62,7 @@ public:
             const auto& kinfit = event.GetKinFitResults();
             if(kinfit.HasValidMass())
                 m_ttbb_kinfit().Fill(kinfit.mass, weight);
+            MT2().Fill(event.GetMT2(), weight);
         }
 
         const double m_SVfit = event.GetHiggsTTMomentum(true).M();

--- a/Analysis/include/LimitsInputProducer.h
+++ b/Analysis/include/LimitsInputProducer.h
@@ -18,7 +18,7 @@ public:
     using AnaDataCollection = ::analysis::EventAnalyzerDataCollection<AnaData>;
     using Sample = ::analysis::SampleDescriptorBase;
     using SampleWP = Sample::Point;
-    using SampleWPCollection = std::vector<SampleWP>;
+    using SampleWPCollection = std::map<std::string, SampleWP>;
     using Hist = TH1D;
     using HistPtr = std::shared_ptr<root_ext::SmartHistogram<Hist>>;
 
@@ -50,21 +50,12 @@ public:
         anaDataCollection(&_anaDataCollection)
     {
         CollectWorkingPoints(std::forward<Args>(sample_descriptors)...);
-        for(const auto& sample : sample_descs) {
-            if(sample.datacard_name.size() || sample.datacard_name_ex.size())
-                samples.push_back(&sample);
-        }
     }
 
-    void ProduceLimitsInput(const std::string& outputFileNamePrefix, const std::string& hist_name,
-                            const EventCategorySet& eventCategories, EventSubCategory eventSubCategory,
-                            const EventEnergyScaleSet& eventEnergyScales)
+    void Produce(const std::string& outputFileNamePrefix, const std::string& hist_name,
+                 const std::map<EventCategory, std::string>& eventCategories, EventSubCategory eventSubCategory,
+                 const EventEnergyScaleSet& eventEnergyScales)
     {
-        static const std::map<EventCategory, std::string> categoryToDirectoryNameSuffix = {
-            { EventCategory::TwoJets_ZeroBtag, "res0b" }, { EventCategory::TwoJets_OneBtag, "res1b" },
-            { EventCategory::TwoJets_TwoBtag, "res2b" }
-        };
-
         static constexpr double tiny_value = 1e-9;
         static constexpr double tiny_value_error = tiny_value;
 
@@ -74,45 +65,31 @@ public:
             s_file_name << "_" << eventSubCategory;
         s_file_name << ".root";
         const std::string file_name = s_file_name.str();
-
         auto outputFile = root_ext::CreateRootFile(file_name);
-        for(EventCategory eventCategory : eventCategories) {
-            if(!categoryToDirectoryNameSuffix.count(eventCategory)) continue;
-            const std::string directoryName = ToString(ChannelId()) + "_"
-                                            + categoryToDirectoryNameSuffix.at(eventCategory);
-            TDirectory* directory = root_ext::GetDirectory(*outputFile, directoryName, true);
-            for(const Sample* sample : samples) {
-                for(const EventEnergyScale& eventEnergyScale : eventEnergyScales) {
-                    std::vector<std::string> fullNames;
-                    for(size_t n = 0; n < sample.GetNSignalPoints(); ++n)
-                        fileNames.emplace_back(sample.GetFullName(n), sample.GetFileName(n));
-                    if(!fullNames.size())
-                        fullNames.push_back(sample->name);
-                    const EventAnalyzerDataId dataId(eventCategory, eventSubCategory, eventEnergyScale,
-                                                     EventRegion::SignalRegion(), sample->name)
-                    const EventAnalyzerDataMetaId_noRegion_noName meta_id(eventCategory, eventSubCategory,
-                                                                         eventEnergyScale);
-                    std::shared_ptr<TH1D> hist;
-                    if(auto hist_orig = GetSignalHistogram(meta_id, dataCategory->name, hist_name))
-                        hist = std::shared_ptr<TH1D>(new TH1D(*hist_orig));
-                    else {
-                        std::cout << "Warning - Datacard histogram '" << hist_name
-                                  << "' not found for data category '" << dataCategory->name << "' in '"
-                                  << eventCategory << "/" << eventSubCategory << "/" << eventEnergyScale
-                                  << "'. Using histogram with a tiny yield in the central bin instead.\n";
 
-                        EventAnalyzerData& anaData = GetAnaData(meta_id.MakeId(EventRegion::OS_Isolated,
-                                                                              dataCategory->name));
-                        auto& new_hist = (anaData.*histogramAccessor)();
-                        hist = std::shared_ptr<TH1D>(new TH1D(new_hist));
-                        const Int_t central_bin = hist->GetNbinsX() / 2;
-                        hist->SetBinContent(central_bin, tiny_value);
-                        hist->SetBinError(central_bin, tiny_value_error);
-                    }
-                    const std::string full_datacard_name = FullDataCardName(sample->datacard_name, eventEnergyScale);
-                    root_ext::WriteObject(*hist, directory, full_datacard_name);
-                }
+
+        for(const EventAnalyzerDataId& metaId : EventAnalyzerDataId::MetaLoop(eventCategories, eventEnergyScales,
+                                                                              sampleWorkingPoints))
+        {
+            const std::string directoryName = ToString(ChannelId()) + "_"
+                                            + eventCategories.at(metaId.Get<EventCategory>());
+            TDirectory* directory = root_ext::GetDirectory(*outputFile, directoryName, true);
+            const SampleWP& sampleWP = sampleWorkingPoints.at(metaId.Get<std::string>());
+            const auto anaDataId = metaId.Set(eventSubCategory).Set(EventRegion::SignalRegion());
+            const auto& anaData = anaDataCollection->Get(anaDataId);
+            auto& hist_entry = anaData.template GetEntryEx<TH1D>(hist_name);
+            auto hist = std::make_shared<TH1D>(hist_entry());
+            if(hist->Integral() == 0.)
+            if(hist_entry().Integral() == 0.) {
+                std::cout << "Warning - Datacard histogram '" << hist_name
+                          << "' has 0 events for '" << anaDataId
+                          << "'. Using histogram with a tiny yield in the central bin instead.\n";
+                const Int_t central_bin = hist->GetNbinsX() / 2;
+                hist->SetBinContent(central_bin, tiny_value);
+                hist->SetBinError(central_bin, tiny_value_error);
             }
+            const auto datacard_name = FullDataCardName(sampleWP.datacard_name, metaId.Get<EventEnergyScale>());
+            root_ext::WriteObject(*hist, directory, datacard_name);
         }
     }
 
@@ -123,9 +100,9 @@ private:
     void CollectWorkingPoints(const SampleCollection& sample_descriptors, Args&&... other_sample_descriptors)
     {
         for(const auto& sample : sample_descriptors) {
-            for(const SampleWP& wp : sample.working_points) {
-                if(wp.datacard_name)
-                    sampleWorkingPoints.push_back(wp);
+            for(const SampleWP& wp : sample.second.working_points) {
+                if(wp.datacard_name.size())
+                    sampleWorkingPoints[wp.full_name] = wp;
             }
         }
         CollectWorkingPoints(std::forward<Args>(other_sample_descriptors)...);

--- a/Analysis/include/SampleDescriptor.h
+++ b/Analysis/include/SampleDescriptor.h
@@ -23,9 +23,10 @@ struct AnalyzerSetup {
     double int_lumi{0};
     std::vector<std::string> final_variables;
     bool apply_mass_cut{false}, apply_os_cut{true}, apply_iso_cut{true};
-    std::set<EventEnergyScale> energy_scales;
+    EventEnergyScaleSet energy_scales;
     std::vector<std::string> data, signals, backgrounds, cmb_samples;
     std::vector<std::string> draw_sequence;
+    std::map<EventCategory, std::string> limit_categories;
 };
 
 using AnalyzerSetupCollection = std::unordered_map<std::string, AnalyzerSetup>;

--- a/Analysis/include/SampleDescriptorConfigEntryReader.h
+++ b/Analysis/include/SampleDescriptorConfigEntryReader.h
@@ -16,7 +16,7 @@ public:
     virtual void EndEntry() override
     {
         CheckReadParamCounts("int_lumi", 1, Condition::less_equal);
-        CheckReadParamCounts("final_variable", 0, Condition::greater_equal);
+        CheckReadParamCounts("final_variables", 1, Condition::less_equal);
         CheckReadParamCounts("apply_mass_cut", 1, Condition::less_equal);
         CheckReadParamCounts("apply_os_cut", 1, Condition::less_equal);
         CheckReadParamCounts("apply_iso_cut", 1, Condition::less_equal);
@@ -26,6 +26,7 @@ public:
         CheckReadParamCounts("backgrounds", 1, Condition::less_equal);
         CheckReadParamCounts("cmb_samples", 1, Condition::less_equal);
         CheckReadParamCounts("draw_sequence", 1, Condition::less_equal);
+        CheckReadParamCounts("limit_category", 0, Condition::greater_equal);
 
         ConfigEntryReaderT<AnalyzerSetup>::EndEntry();
     }
@@ -34,7 +35,7 @@ public:
                                std::istringstream& /*ss*/) override
     {
         ParseEntry("int_lumi", current.int_lumi);
-        ParseEntry("final_variable", current.final_variables);
+        ParseEntryList("final_variables", current.final_variables);
         ParseEntry("apply_mass_cut", current.apply_mass_cut);
         ParseEntry("apply_os_cut", current.apply_os_cut);
         ParseEntry("apply_iso_cut", current.apply_iso_cut);
@@ -44,6 +45,7 @@ public:
         ParseEntryList("backgrounds", current.backgrounds);
         ParseEntryList("cmb_samples", current.cmb_samples);
         ParseEntryList("draw_sequence", current.draw_sequence);
+        ParseEntry("limit_category", current.limit_categories);
     }
 };
 


### PR DESCRIPTION
- Analyzer configuraton:
  - added limit_category map;
  - final_variable -> final_variables;
  - defined reduced setup for debug purposes;
  - fixed datacard names.
- AnalysisCategories.h: implemented Parse for EventCategory and EventSubCategory.
- BaseEventAnalyzer.h:
  - running limits input producer;
  - using MetaLoop inside AddSampleToCombined.
- EventAnalyzerData.h: fixed binning for kinfit and added MT2.
- EventAnalyzerDataCollection.h: implemented EventAnalyzerDataId::MetaLoop.
- LimitsInputProducer.h:
  - produces distributions that are used as an input for the limit computation;
  - using naming convention defined for the 2016 analysis.