### PR TITLE
Implemented MVA support in BaseEventAnalyzer

### DIFF
--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -1,8 +1,9 @@
 [ANA_DESC common]
 int_lumi: 35900
-final_variables: m_ttbb_kinfit MT2
+final_variables: m_ttbb_kinfit MT2 mva_score
 apply_mass_cut: true
 energy_scales: all
+mva_setup: mva_v1
 limit_category: 2jets0btag res0b
 limit_category: 2jets1btag res1b
 limit_category: 2jets2btag res2b
@@ -20,6 +21,13 @@ backgrounds: DY
 data: Data_SingleElectron Data_SingleMuon Data_Tau
 cmb_samples: DY_cmb
 draw_sequence: Signal_Radion Signal_SM DY_cmb data
+
+[MVA mva_v1]
+training: SM hh-bbtautau/Analysis/config/mva/myFactorySM16_blind_0_Grad_0.weights.xml
+variables: SM pt_b1 pt_b2 pt_hbb pt_l1 pt_l2 pt_l1l2MET pt_htautau HT_otherjets p_zeta p_zetavisible abs_dphi_l1MET dphi_hbbhtautau dR_l1l2 dR_b1b2 MT_tot mass_top2 costheta_METhbb channel
+masses: SM 125
+spins: SM 0
+cuts: SM -1 0.5 0.6 0.7 0.8 0.9 0.95
 
 [DY]
 file_path: DYJetsToLL_M-50.root
@@ -93,7 +101,7 @@ points: M 250 260 270 280 300 320 340 350 400 450 500 550 600 650 750 800 900
 title: Radion M{M} GeV (arb. units)
 draw_ex: M250 kYellow
 draw_ex: M600 kBlue
-draw_sf: 5
+draw_sf: 0.1
 channels: eTau muTau tauTau
 sample_type: MC
 datacard_name: ggRadion_hh_ttbb_M{M}
@@ -118,7 +126,7 @@ title: {factor} SM HH#rightarrowbb#tau#tau
 color: kBlack
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: ggh_hh_ttbb_kl0
+datacard_name: ggh_hh_ttbb_kl1
 
 [Data_SingleElectron]
 file_path: SingleElectron_2016.root

--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -3,7 +3,7 @@ int_lumi: 35900
 final_variables: m_ttbb_kinfit MT2 mva_score
 apply_mass_cut: true
 energy_scales: all
-#mva_setup: mva_v1
+mva_setup: mva_v1
 limit_category: 2jets1btag res1b
 limit_category: 2jets2btag res2b
 
@@ -12,14 +12,7 @@ signals: Signal_Radion Signal_Graviton Signal_SM
 backgrounds: TT DY Wjets WW WZ ZZ ZH EWK tW QCD
 data: Data_SingleElectron Data_SingleMuon Data_Tau
 cmb_samples: DY_cmb other_bkg
-draw_sequence: Signal_Radion Signal_SM ZH other_bkg DY_cmb QCD TT data
-
-[ANA_DESC reduced : common]
-signals: Signal_Radion Signal_SM
-backgrounds: DY
-data: Data_SingleElectron Data_SingleMuon Data_Tau
-cmb_samples: DY_cmb
-draw_sequence: Signal_Radion Signal_SM DY_cmb data
+draw_sequence: data Signal_SM Signal_Radion TT QCD DY_cmb other_bkg ZH
 
 [ANA_DESC muMu]
 int_lumi: 35900
@@ -65,7 +58,7 @@ file_path: TT.root
 cross_section: 831.76
 title: tt
 color: kRed
-sample_type: MC
+sample_type: TT
 datacard_name: TT
 
 [tW]
@@ -113,7 +106,7 @@ points: M 250 260 270 280 300 320 340 350 400 450 500 550 600 650 750 800 900
 title: Radion M{M} GeV (arb. units)
 draw_ex: M250 kYellow
 draw_ex: M600 kBlue
-draw_sf: 0.1
+draw_sf: 0.05
 channels: eTau muTau tauTau
 sample_type: MC
 datacard_name: ggRadion_hh_ttbb_M{M}
@@ -131,10 +124,10 @@ datacard_name: ggGraviton_hh_ttbb_M{M}
 
 [Signal_SM]
 file_path: ggHH_SM.root
-cross_section: 0.03345
-datacard_sf: 1./0.03345
+cross_section: 0.03345 * 2 * 5.809e-01 * 6.256e-02
+datacard_sf: 1./( 0.03345 * 2 * 5.809e-01 * 6.256e-02 )
 draw_sf: 50
-title: {factor} SM HH#rightarrowbb#tau#tau
+title: {factor}x SM HH#rightarrowbb#tau#tau
 color: kBlack
 channels: eTau muTau tauTau
 sample_type: MC

--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -4,7 +4,6 @@ final_variables: m_ttbb_kinfit MT2 mva_score
 apply_mass_cut: true
 energy_scales: all
 #mva_setup: mva_v1
-limit_category: 2jets0btag res0b
 limit_category: 2jets1btag res1b
 limit_category: 2jets2btag res2b
 

--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -3,7 +3,7 @@ int_lumi: 35900
 final_variables: m_ttbb_kinfit MT2 mva_score
 apply_mass_cut: true
 energy_scales: all
-mva_setup: mva_v1
+#mva_setup: mva_v1
 limit_category: 2jets0btag res0b
 limit_category: 2jets1btag res1b
 limit_category: 2jets2btag res2b

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -10,9 +10,10 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 
 namespace analysis {
 
-enum class SampleType { Data, MC, DY, QCD };
+enum class SampleType { Data, MC, DY, QCD, TT };
 ENUM_NAMES(SampleType) = {
-    { SampleType::Data, "Data" }, { SampleType::MC, "MC" }, { SampleType::DY, "DY" }, { SampleType::QCD, "QCD" }
+    { SampleType::Data, "Data" }, { SampleType::MC, "MC" }, { SampleType::DY, "DY" }, { SampleType::QCD, "QCD" },
+    { SampleType::TT, "TT" }
 };
 
 struct EventRegion {

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -237,6 +237,8 @@ struct EventSubCategory {
             throw exception("Cut '%1%' is aready defined.") % cut;
         results[GetIndex(cut)] = result;
         presence[GetIndex(cut)] = true;
+        if(cut >= SelectionCut::MVA_first && cut <= SelectionCut::MVA_last)
+            last_mva_cut = cut;
         return *this;
     }
 
@@ -260,6 +262,13 @@ struct EventSubCategory {
         if((pres_a ^ pres_b) & pres_b) return false;
         const BitsContainer res_a = GetResultBits(), res_b = sc.GetResultBits();
         return (res_a & pres_b) == res_b;
+    }
+
+    bool TryGetLastMvaCut(SelectionCut& cut) const
+    {
+        if(!last_mva_cut.is_initialized()) return false;
+        cut = *last_mva_cut;
+        return true;
     }
 
     std::string ToString() const
@@ -308,6 +317,7 @@ private:
 
 private:
     Bits presence, results;
+    boost::optional<SelectionCut> last_mva_cut;
 };
 
 std::ostream& operator<<(std::ostream& os, const EventSubCategory& eventSubCategory)

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -450,10 +450,10 @@ protected:
         } else if(sample.sampleType == SampleType::TT) {
             anaDataCollection.Fill(anaDataId, event, weight / event->weight_top_pt);
             if(anaDataId.Get<EventEnergyScale>() == EventEnergyScale::Central) {
-                const double weight_topPt = event->weight_total * sample.cross_section * ana_setup.int_lumi
-                        / event.GetSummaryInfo()->totalShapeWeight_withTopPt;
-                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtUp), event, weight_topPt);
-                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtDown), event, weight_topPt);
+//                const double weight_topPt = event->weight_total * sample.cross_section * ana_setup.int_lumi
+//                        / event.GetSummaryInfo()->totalShapeWeight_withTopPt;
+                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtUp), event, weight); // FIXME
+                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtDown), event, weight); // FIXME
             }
         } else
             throw exception("Unsupported special event type '%1%'.") % sample.sampleType;

--- a/Analysis/include/EventAnalyzerData.h
+++ b/Analysis/include/EventAnalyzerData.h
@@ -23,6 +23,7 @@ public:
     TH1D_ENTRY_CUSTOM_EX(m_ttbb_kinfit, M_ttbb_Bins, "M_{H}^{kinfit} (GeV)", "dN/dm_{H}^{kinfit} (1/GeV)", false, 1.4, true, true)
     TH1D_ENTRY_CUSTOM_EX(m_sv, M_tt_Bins, "M_{#tau#tau} (GeV)", "dN/dm_{#tau#tau} (1/GeV)", false, 1.3, true, true)
     TH1D_ENTRY_CUSTOM_EX(MT2, MT2_Bins, "MT2_{H} (GeV)", "dN/dm (1/GeV)", false, 1.4, true, true)
+    TH1D_ENTRY_EX(mva_score, 40, -1, 1, "MVA score", "Events", false, 1.2, false, true)
 
     TH1D_ENTRY_CUSTOM_EX(m_tt_vis, M_tt_Bins, "M_{vis}(GeV)", "Events", false, 1.1, false, SaveAll)
     TH1D_ENTRY_EX(pt_H_tt, 20, 0, 300, "P_{T}(GeV)", "Events", false, 1.2, false, SaveAll)
@@ -63,6 +64,7 @@ public:
             if(kinfit.HasValidMass())
                 m_ttbb_kinfit().Fill(kinfit.mass, weight);
             MT2().Fill(event.GetMT2(), weight);
+            mva_score().Fill(event.GetMvaScore(), weight);
         }
 
         const double m_SVfit = event.GetHiggsTTMomentum(true).M();

--- a/Analysis/include/EventAnalyzerDataCollection.h
+++ b/Analysis/include/EventAnalyzerDataCollection.h
@@ -199,9 +199,9 @@ private:
             if(!id.IsComplete())
                 throw exception("EventAnalyzerDataId '%1%' is not complete.") % id;
             const std::string dir_name = id.GetName();
-            return std::make_shared<Data>(file, dir_name, fill_all, readMode);
+            return std::make_shared<Data>(file, dir_name, id.Get<EventCategory>(), fill_all, readMode);
         }
-        return std::make_shared<Data>(fill_all);
+        return std::make_shared<Data>(id.Get<EventCategory>(), fill_all);
     }
 
 private:

--- a/Analysis/include/LimitsInputProducer.h
+++ b/Analysis/include/LimitsInputProducer.h
@@ -79,8 +79,8 @@ public:
             const auto& anaData = anaDataCollection->Get(anaDataId);
             auto& hist_entry = anaData.template GetEntryEx<TH1D>(hist_name);
             auto hist = std::make_shared<TH1D>(hist_entry());
-            if(hist->Integral() == 0.)
-            if(hist_entry().Integral() == 0.) {
+            hist->Scale(sampleWP.datacard_sf);
+            if(hist->Integral() == 0.) {
                 std::cout << "Warning - Datacard histogram '" << hist_name
                           << "' has 0 events for '" << anaDataId
                           << "'. Using histogram with a tiny yield in the central bin instead.\n";

--- a/Analysis/include/LimitsInputProducer.h
+++ b/Analysis/include/LimitsInputProducer.h
@@ -70,6 +70,8 @@ public:
         const std::string file_name = s_file_name.str();
         auto outputFile = root_ext::CreateRootFile(file_name);
 
+        std::set<EventAnalyzerDataId> empty_histograms;
+
         for(const EventAnalyzerDataId& metaId : EventAnalyzerDataId::MetaLoop(eventCategories, eventEnergyScales,
                                                                               sampleWorkingPoints, eventRegions))
         {
@@ -78,21 +80,34 @@ public:
                 directoryName += "_" + ToString(metaId.Get<EventRegion>());
             TDirectory* directory = root_ext::GetDirectory(*outputFile, directoryName, true);
             const SampleWP& sampleWP = sampleWorkingPoints.at(metaId.Get<std::string>());
-            const auto anaDataId = metaId.Set(eventSubCategory).Set(EventRegion::SignalRegion());
+            const auto anaDataId = metaId.Set(eventSubCategory).Set(metaId.Get<EventRegion>());
             const auto& anaData = anaDataCollection->Get(anaDataId);
             auto& hist_entry = anaData.template GetEntryEx<TH1D>(hist_name);
-            auto hist = std::make_shared<TH1D>(hist_entry());
-            hist->Scale(sampleWP.datacard_sf);
-            if(hist->Integral() == 0.) {
-                std::cout << "Warning - Datacard histogram '" << hist_name
-                          << "' has 0 events for '" << anaDataId
-                          << "'. Using histogram with a tiny yield in the central bin instead.\n";
+            std::shared_ptr<TH1D> hist;
+            if(hist_entry.GetHistograms().count(""))
+                hist = std::make_shared<TH1D>(hist_entry());
+            if(hist)
+                hist->Scale(sampleWP.datacard_sf);
+            if(!hist || hist->Integral() == 0.) {
+                bool print_warning;
+                if(CanHaveEmptyHistogram(anaDataId, print_warning)) continue;
+                if(print_warning)
+                    empty_histograms.insert(anaDataId);
+                if(!hist)
+                    hist = std::make_shared<TH1D>(hist_entry());
                 const Int_t central_bin = hist->GetNbinsX() / 2;
                 hist->SetBinContent(central_bin, tiny_value);
                 hist->SetBinError(central_bin, tiny_value_error);
             }
             const auto datacard_name = FullDataCardName(sampleWP.datacard_name, metaId.Get<EventEnergyScale>());
             root_ext::WriteObject(*hist, directory, datacard_name);
+        }
+
+        if(empty_histograms.size()) {
+            std::cout << "\t\tWarning: following datacard histograms are empty:\n";
+            for(const auto& id : empty_histograms)
+                std::cout << "\t\t\t" << id << "\n";
+            std::cout << "\t\tUsing histograms with a tiny yield in the central bin instead." << std::endl;
         }
     }
 
@@ -109,6 +124,20 @@ private:
             }
         }
         CollectWorkingPoints(std::forward<Args>(other_sample_descriptors)...);
+    }
+
+    bool CanHaveEmptyHistogram(const EventAnalyzerDataId& id, bool& print_warning) const
+    {
+        const auto& es = id.Get<EventEnergyScale>();
+        const SampleWP& sampleWP = sampleWorkingPoints.at(id.Get<std::string>());
+        print_warning = id.Get<EventRegion>() == EventRegion::SignalRegion();
+        if(es == EventEnergyScale::Central)
+            return false;
+        if(sampleWP.sampleType == SampleType::Data || sampleWP.sampleType == SampleType::QCD)
+            return true;
+        if(es == EventEnergyScale::TopPtUp || es == EventEnergyScale::TopPtDown)
+            return sampleWP.sampleType != SampleType::TT;
+        return false;
     }
 
 private:

--- a/Analysis/include/SampleDescriptor.h
+++ b/Analysis/include/SampleDescriptor.h
@@ -107,6 +107,7 @@ using MvaReaderSetupCollection = std::unordered_map<std::string, MvaReaderSetup>
 struct SampleDescriptorBase {
     struct Point {
         std::string name, full_name, title, file_path, datacard_name;
+        SampleType sampleType;
         double norm_sf{1}, datacard_sf{1}, draw_sf{1};
         bool draw{false};
         root_ext::Color color{kBlack};
@@ -140,6 +141,7 @@ struct SampleDescriptorBase {
         point.title = title.size() ? title : point.full_name;
         ReplacePatternItem(point.title, "factor", draw_sf);
         point.datacard_name = datacard_name;
+        point.sampleType = sampleType;
         point.draw_sf = draw_sf;
         point.datacard_sf = datacard_sf;
         point.draw = true;
@@ -188,6 +190,7 @@ public:
             ReplacePatternItem(point.title, "factor", draw_sf);
             point.file_path = ResolvePattern(file_path, n);
             point.datacard_name = ResolvePattern(datacard_name, n);
+            point.sampleType = sampleType;
             point.norm_sf = n < norm_sf.size() ? norm_sf.at(n) : 1;
             point.draw_sf = draw_sf;
             point.datacard_sf = datacard_sf;

--- a/Analysis/include/SampleDescriptor.h
+++ b/Analysis/include/SampleDescriptor.h
@@ -41,10 +41,11 @@ struct MvaReaderSetup {
 
     std::string name;
     std::map<std::string, std::string> trainings;
-    std::map<std::string, std::vector<std::string>> variables;
+    std::map<std::string, std::unordered_set<std::string>> variables;
     std::map<std::string, std::vector<double>> masses;
     std::map<std::string, std::vector<int>> spins;
     std::map<std::string, std::vector<double>> cuts;
+    std::map<std::string, std::string> legacy;
 
     std::map<SelectionCut, Params> selections;
 

--- a/Analysis/include/SampleDescriptorConfigEntryReader.h
+++ b/Analysis/include/SampleDescriptorConfigEntryReader.h
@@ -27,6 +27,7 @@ public:
         CheckReadParamCounts("cmb_samples", 1, Condition::less_equal);
         CheckReadParamCounts("draw_sequence", 1, Condition::less_equal);
         CheckReadParamCounts("limit_category", 0, Condition::greater_equal);
+        CheckReadParamCounts("mva_setup", 1, Condition::less_equal);
 
         ConfigEntryReaderT<AnalyzerSetup>::EndEntry();
     }
@@ -46,6 +47,7 @@ public:
         ParseEntryList("cmb_samples", current.cmb_samples);
         ParseEntryList("draw_sequence", current.draw_sequence);
         ParseEntry("limit_category", current.limit_categories);
+        ParseEntry("mva_setup", current.mva_setup);
     }
 };
 
@@ -61,7 +63,9 @@ public:
         CheckReadParamCounts("masses", 0, Condition::greater_equal);
         CheckReadParamCounts("spins", 0, Condition::greater_equal);
         CheckReadParamCounts("cuts", 0, Condition::greater_equal);
+        CheckReadParamCounts("legacy", 0, Condition::greater_equal);
 
+        current.CreateSelections();
         ConfigEntryReaderT<MvaReaderSetup>::EndEntry();
     }
 
@@ -73,6 +77,7 @@ public:
         ParseMappedEntryList("masses", current.masses, true);
         ParseMappedEntryList("spins", current.spins, true);
         ParseMappedEntryList("cuts", current.cuts, false);
+        ParseEntry("legacy", current.legacy);
     }
 };
 

--- a/Analysis/include/StackedPlotsProducer.h
+++ b/Analysis/include/StackedPlotsProducer.h
@@ -103,9 +103,7 @@ public:
                             const auto histogram = GetHistogram(anaDataMetaId, item_name, hist_name);
                             if(!histogram) continue;
 
-                            if(signals.count(sample->name) && eventCategory == EventCategory::TwoJets_Inclusive())
-                                continue;
-                            else if(signals.count(sample->name))
+                            if(signals.count(sample->name))
                                 stackDescriptor.AddSignalHistogram(*histogram, item.title, color, sample->draw_sf);
                             else if(sample->sampleType == SampleType::Data)
                                 stackDescriptor.AddDataHistogram(*histogram, item.title, isBlind,

--- a/Analysis/source/bbetauAnalyzer.cxx
+++ b/Analysis/source/bbetauAnalyzer.cxx
@@ -22,8 +22,8 @@ protected:
 
         if(!event.GetTriggerResults().AnyAcceptAndMatch(trigger_patterns)) return EventRegion::Unknown();
 
-//        if(ana_setup.apply_iso_cut && !tau->byIsolationMVA(DiscriminatorWP::VLoose))
-//            return EventRegion::Unknown();
+        if(ana_setup.apply_iso_cut && !tau->byIsolationMVA(DiscriminatorWP::VLoose))
+            return EventRegion::Unknown();
 
         const bool os = !ana_setup.apply_os_cut || electron.GetCharge() * tau.GetCharge() == -1;
         const bool iso = !ana_setup.apply_iso_cut || tau->byIsolationMVA(DiscriminatorWP::Medium);

--- a/Analysis/source/bbmutauAnalyzer.cxx
+++ b/Analysis/source/bbmutauAnalyzer.cxx
@@ -22,8 +22,8 @@ protected:
 
         if(!event.GetTriggerResults().AnyAcceptAndMatch(trigger_patterns)) return EventRegion::Unknown();
 
-//        if(ana_setup.apply_iso_cut && !tau->byIsolationMVA(DiscriminatorWP::VLoose))
-//            return EventRegion::Unknown();
+        if(ana_setup.apply_iso_cut && !tau->byIsolationMVA(DiscriminatorWP::VLoose))
+            return EventRegion::Unknown();
 
         const bool os = !ana_setup.apply_os_cut || muon.GetCharge() * tau.GetCharge() == -1;
         const bool iso = !ana_setup.apply_iso_cut || tau->byIsolationMVA(DiscriminatorWP::Medium);

--- a/Analysis/source/bbtautauAnalyzer.cxx
+++ b/Analysis/source/bbtautauAnalyzer.cxx
@@ -2,6 +2,7 @@
 This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 
 #include "Analysis/include/BaseEventAnalyzer.h"
+#include "h-tautau/McCorrections/include/TauIdWeight.h"
 
 namespace analysis {
 
@@ -9,6 +10,12 @@ class bbtautauAnalyzer : public BaseEventAnalyzer<TauCandidate, TauCandidate> {
 public:
     using Base = BaseEventAnalyzer<TauCandidate, TauCandidate>;
     using Base::BaseEventAnalyzer;
+
+    bbtautauAnalyzer(const AnalyzerArguments& _args) :
+        Base(_args), gen(174296), dm_prob_distr(0, 1),
+        id_weight_calc("h-tautau/McCorrections/data/fitresults_tt_moriond2017.json", DiscriminatorWP::Medium)
+    {
+    }
 
 protected:
     virtual EventRegion DetermineEventRegion(EventInfo& event, EventCategory /*eventCategory*/) override
@@ -27,11 +34,42 @@ protected:
                 (tau_1->byIsolationMVA(DiscriminatorWP::Medium) || tau_2->byIsolationMVA(DiscriminatorWP::Medium))))
             return EventRegion::Unknown();
 
+        CorrectIdWeight(event);
+
         const bool os = !ana_setup.apply_os_cut || tau_1.GetCharge() * tau_2.GetCharge() == -1;
         const bool iso = !ana_setup.apply_iso_cut ||
                 ( tau_1->byIsolationMVA(DiscriminatorWP::Medium) && tau_2->byIsolationMVA(DiscriminatorWP::Medium) );
         return EventRegion(os, iso);
     }
+
+private:
+    void CorrectIdWeight(EventInfo& eventInfo)
+    {
+        auto& event = *const_cast<ntuple::Event*>(&(*eventInfo));
+        event.decayMode_1 = GenDecayMode();
+        event.decayMode_2 = GenDecayMode();
+        const double id_weight = id_weight_calc.Get(event);
+        event.weight_total *= id_weight;
+    }
+
+    int GenDecayMode()
+    {
+        static const std::vector<double> dm_prob = { 0.1151, 0.37, 0.1521 };
+        static const double total_prob = std::accumulate(dm_prob.begin(), dm_prob.end(), 0.);
+        static const std::vector<int> decay_modes = { 0, 1, 10 };
+        double prob = dm_prob_distr(gen) * total_prob;
+        for(size_t n = 0; n < dm_prob.size(); ++n) {
+            if(prob <= dm_prob.at(n))
+                return decay_modes.at(n);
+            prob -= dm_prob.at(n);
+        }
+        throw exception("Unable to generate DM.");
+    }
+
+private:
+    std::mt19937_64 gen;
+    std::uniform_real_distribution<double> dm_prob_distr;
+    mc_corrections::TauIdWeight id_weight_calc;
 };
 
 } // namespace analysis

--- a/Analysis/source/bbtautauAnalyzer.cxx
+++ b/Analysis/source/bbtautauAnalyzer.cxx
@@ -22,10 +22,10 @@ protected:
 
         if(!event.GetTriggerResults().AnyAcceptAndMatch(trigger_patterns)) return EventRegion::Unknown();
 
-//        if(ana_setup.apply_iso_cut &&
-//                !(tau_1->byIsolationMVA(DiscriminatorWP::VLoose) && tau_2->byIsolationMVA(DiscriminatorWP::VLoose) &&
-//                (tau_1->byIsolationMVA(DiscriminatorWP::Medium) || tau_2->byIsolationMVA(DiscriminatorWP::Medium))))
-//            return EventRegion::Unknown();
+        if(ana_setup.apply_iso_cut &&
+                !(tau_1->byIsolationMVA(DiscriminatorWP::VLoose) && tau_2->byIsolationMVA(DiscriminatorWP::VLoose) &&
+                (tau_1->byIsolationMVA(DiscriminatorWP::Medium) || tau_2->byIsolationMVA(DiscriminatorWP::Medium))))
+            return EventRegion::Unknown();
 
         const bool os = !ana_setup.apply_os_cut || tau_1.GetCharge() * tau_2.GetCharge() == -1;
         const bool iso = !ana_setup.apply_iso_cut ||

--- a/Instruments/config/Skimmer.cfg
+++ b/Instruments/config/Skimmer.cfg
@@ -6,14 +6,14 @@ n_splits: 120
 split_seed: 1234567
 
 [SETUP light_setup : setup_base]
-channels: eTau muMu muTau tauTau
+channels: eTau muTau tauTau
 energy_scales: Central
 apply_mass_cut: true
 apply_charge_cut: true
 tau_id_cut: byMediumIsolationMVArun2v1DBoldDMwLT 0.5
 
 [SETUP mh_setup : setup_base]
-channels: eTau muMu muTau tauTau
+channels: eTau muTau tauTau
 energy_scales: all
 apply_mass_cut: true
 tau_ids: byVLooseIsolationMVArun2v1DBoldDMwLT byMediumIsolationMVArun2v1DBoldDMwLT


### PR DESCRIPTION
- Analysis/config/sources.cfg:
  - added mva setup;
  - removed 0btag category from limits outputs;
  - removed reduced setup;
  - changed drawing sequence;
  - fixed SM signal XS.
- Analysis/include/AnalysisCategories.h:
  - added SampleType::TT;
  - store last MVA selection cut in EventSubCategory;
- Analysis/include/BaseEventAnalyzer.h:
  - implemented MVA sub-categories;
  - estimate topPt ES uncertainties for TT;
  - added workaround for total topPt ES weight;
  - estimate QCD only for the central ES.
- Analysis/include/EventAnalyzerData.h:
  - changed binning for mva_score;
  - added EventCategory to the constructor arguments.
- Analysis/include/LimitsInputProducer.h:
  - produce shapes for topPt unc;
  - less verbose warnings.
- Analysis/include/SampleDescriptor.h:
  - added sample type to sample wp;
  - added legacy flag to mva config.
- Analysis/include/StackedPlotsProducer.h: draw signal in all categories.
- Analysis/source/bb*tauAnalyzer.cxx: uncommented VLoose iso cut.
- Analysis/source/bbtautauAnalyzer.cxx:
  - added workaround for decay_mode in tauTau channel: randomly select tau decay modes and set weights accordingly...
- Instruments/config/Skimmer.cfg:
  - excluded muMu channel from mh and light setups.