### PR TITLE
Fixed mva_score and MT2 binning + bugfixes

### DIFF
--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -3,7 +3,7 @@ int_lumi: 35882.549
 final_variables: m_ttbb_kinfit MT2 mva_score
 apply_mass_cut: true
 energy_scales: all
-mva_setup: mva_all
+mva_setup: mva_sm
 limit_category: 2jets1btagR res1b
 limit_category: 2jets2btagR res2b
 limit_category: 2jets2LoosebtagB boosted
@@ -56,7 +56,7 @@ training: LM_AN hh-bbtautau/Analysis/config/mva/HIG-17-002-BDT-LowMass.xml
 variables: LM_AN dphi_l1MET dphi_htautauMET dphi_hbbMET dphi_hbbhtautau dR_b1b2Pt_hbb dR_l1l2Pt_htautau MT_l1 MT_l2
 spins: LM_AN 0
 masses: LM_AN 250
-cuts: LM_AN -1 −0.0764 0.477
+cuts: LM_AN -1 -0.0764 0.477
 legacy: LM_AN lm
 training: HM_AN hh-bbtautau/Analysis/config/mva/HIG-17-002-BDT-HighMass.xml
 variables: HM_AN dphi_l1MET dphi_htautauMET dphi_hbbMET dphi_hbbhtautau dR_b1b2 dR_l1l2 MT_l1 MT_l2

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -356,7 +356,7 @@ inline std::map<SelectionCut, std::string> CreateSelectionCutNames()
 ENUM_NAMES(SelectionCut) = detail::CreateSelectionCutNames();
 
 struct EventSubCategory {
-    using BitsContainer = boost::multiprecision::uint128_t;
+    using BitsContainer = unsigned long long;
     static constexpr size_t MaxNumberOfCuts = std::numeric_limits<BitsContainer>::digits;
     using Bits = std::bitset<MaxNumberOfCuts>;
 

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -356,35 +356,43 @@ inline std::map<SelectionCut, std::string> CreateSelectionCutNames()
 ENUM_NAMES(SelectionCut) = detail::CreateSelectionCutNames();
 
 struct EventSubCategory {
-    using BitsContainer = unsigned long long;
+    using BitsContainer = boost::multiprecision::uint128_t;
     static constexpr size_t MaxNumberOfCuts = std::numeric_limits<BitsContainer>::digits;
-    using Bits = std::bitset<MaxNumberOfCuts>;
 
     static const EventSubCategory& NoCuts() { static const EventSubCategory esc; return esc; }
 
-    EventSubCategory() {}
+    EventSubCategory() : presence(0), results(0) {}
 
-    bool HasCut(SelectionCut cut) const { return presence[GetIndex(cut)]; }
+    bool HasCut(SelectionCut cut) const
+    {
+        const BitsContainer mask = BitsContainer(1) << GetIndex(cut);
+        return (presence & mask) != BitsContainer(0);
+    }
+
     bool Passed(SelectionCut cut) const
     {
         if(!HasCut(cut))
             throw exception("Cut '%1%' is not defined.") % cut;
-        return results[GetIndex(cut)];
+        const BitsContainer mask = BitsContainer(1) << GetIndex(cut);
+        return (results & mask) != BitsContainer(0);
     }
     bool Failed(SelectionCut cut) const { return !Passed(cut); }
+
     EventSubCategory& SetCutResult(SelectionCut cut, bool result)
     {
         if(HasCut(cut))
             throw exception("Cut '%1%' is aready defined.") % cut;
-        results[GetIndex(cut)] = result;
-        presence[GetIndex(cut)] = true;
+        const size_t index = GetIndex(cut);
+        const BitsContainer mask = BitsContainer(1) << index;
+        results = (results & ~mask) | (BitsContainer(result) << index);
+        presence |= mask;
         if(cut >= SelectionCut::MVA_first && cut <= SelectionCut::MVA_last)
             last_mva_cut = cut;
         return *this;
     }
 
-    BitsContainer GetPresenceBits() const { return presence.to_ulong(); }
-    BitsContainer GetResultBits() const { return results.to_ulong(); }
+    BitsContainer GetPresenceBits() const { return presence; }
+    BitsContainer GetResultBits() const { return results; }
 
     bool operator ==(const EventSubCategory& sc) const
     {
@@ -400,7 +408,7 @@ struct EventSubCategory {
     bool Implies(const EventSubCategory& sc) const
     {
         const BitsContainer pres_a = GetPresenceBits(), pres_b = sc.GetPresenceBits();
-        if((pres_a ^ pres_b) & pres_b) return false;
+        if(((pres_a ^ pres_b) & pres_b) != BitsContainer(0)) return false;
         const BitsContainer res_a = GetResultBits(), res_b = sc.GetResultBits();
         return (res_a & pres_b) == res_b;
     }
@@ -416,8 +424,9 @@ struct EventSubCategory {
     {
         std::ostringstream s;
         for(size_t n = 0; n < MaxNumberOfCuts; ++n) {
-            if(!presence[n]) continue;
-            if(!results[n]) s << "not";
+            const BitsContainer mask = BitsContainer(1) << n;
+            if((presence & mask) == BitsContainer(0)) continue;
+            if((results & mask) == BitsContainer(0)) s << "not";
             s << static_cast<SelectionCut>(n) << "_";
         }
         std::string str = s.str();
@@ -457,7 +466,7 @@ private:
     }
 
 private:
-    Bits presence, results;
+    BitsContainer presence, results;
     boost::optional<SelectionCut> last_mva_cut;
 };
 

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -441,21 +441,6 @@ protected:
         for(const auto& es : ana_setup.energy_scales) {
             anaDataCollection.Fill(anaDataId.Set<EventEnergyScale>(es), event, 1);
         }
-
-        if(anaDataId.Get<EventCategory>() == EventCategory::TwoJets_TwoBtag_Resolved()
-                && anaDataId.Get<EventSubCategory>().Implies(EventSubCategory()
-                                                             .SetCutResult(SelectionCut::MVA0, true))
-                && event.GetMvaScore() > 0.7) {
-            auto& hist = anaDataCollection.Get(anaDataId).mva_score();
-            int bin = hist.FindBin(event.GetMvaScore());
-            double bin_content = hist.GetBinContent(bin);
-            std::cout << anaDataId << " " << event.GetMvaScore() << " " << bin << " " << bin_content << std::endl;
-            std::cout << event.GetFirstLeg().GetCharge() << " "
-                      << event.GetFirstLeg()->byIsolationMVA(DiscriminatorWP::Medium) << " "
-                      << event.GetSecondLeg().GetCharge() << " "
-                      << event.GetSecondLeg()->byIsolationMVA(DiscriminatorWP::Medium) << std::endl;
-
-        }
     }
 
     virtual void ProcessSpecialEvent(const SampleDescriptor& sample, const SampleDescriptor::Point& /*sample_wp*/,

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -441,6 +441,21 @@ protected:
         for(const auto& es : ana_setup.energy_scales) {
             anaDataCollection.Fill(anaDataId.Set<EventEnergyScale>(es), event, 1);
         }
+
+        if(anaDataId.Get<EventCategory>() == EventCategory::TwoJets_TwoBtag_Resolved()
+                && anaDataId.Get<EventSubCategory>().Implies(EventSubCategory()
+                                                             .SetCutResult(SelectionCut::MVA0, true))
+                && event.GetMvaScore() > 0.7) {
+            auto& hist = anaDataCollection.Get(anaDataId).mva_score();
+            int bin = hist.FindBin(event.GetMvaScore());
+            double bin_content = hist.GetBinContent(bin);
+            std::cout << anaDataId << " " << event.GetMvaScore() << " " << bin << " " << bin_content << std::endl;
+            std::cout << event.GetFirstLeg().GetCharge() << " "
+                      << event.GetFirstLeg()->byIsolationMVA(DiscriminatorWP::Medium) << " "
+                      << event.GetSecondLeg().GetCharge() << " "
+                      << event.GetSecondLeg()->byIsolationMVA(DiscriminatorWP::Medium) << std::endl;
+
+        }
     }
 
     virtual void ProcessSpecialEvent(const SampleDescriptor& sample, const SampleDescriptor::Point& /*sample_wp*/,

--- a/Analysis/include/EventAnalyzerData.h
+++ b/Analysis/include/EventAnalyzerData.h
@@ -308,12 +308,11 @@ private:
     {
         static const BinVector res1b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
                                                             0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 };
-        static const BinVector res2b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.2, 0.6, 0.7, 0.8, 0.9,
-                                                            1 };
-        static const BinVector boosted_mva_bins = { -1, 0.6, 0.8, 1 };
+        static const BinVector res2b_mva_bins = { -1, -0.8, -0.6, -0.3, 0.1, 0.4, 0.7, 0.85, 1 };
+        static const BinVector boosted_mva_bins = { -1, 0, 0.6, 0.8, 1 };
 
         auto mva_bins = &res1b_mva_bins;
-        auto mva_draw_sf = 1.2;
+        auto mva_draw_sf = 1.4;
         if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
             mva_bins = &boosted_mva_bins;
             mva_draw_sf = 2;

--- a/Analysis/include/EventAnalyzerData.h
+++ b/Analysis/include/EventAnalyzerData.h
@@ -166,12 +166,10 @@ public:
 private:
     void Initialize(const EventCategory& eventCategory)
     {
-        static const std::vector<double> boosted_mva_bins = { -1, 0.4, 0.6, 0.7, 0.8, 0.9, 1 };
+        static const BinVector boosted_MT2_bins = { 0, 150, 200, 250, 300, 500 };
 
         if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
-            auto mva_bins = &boosted_mva_bins;
-            double mva_draw_sf = 2;
-            mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
+            MT2.SetMasterHist(boosted_MT2_bins, "MT2_{H} (GeV)", "dN/dm (1/GeV)", false, 1.4, true, true);
         }
     }
 
@@ -191,6 +189,92 @@ public:
     void Fill(EventInfo& event, double weight)
     {
         FillBase(event, weight);
+    }
+};
+
+template<>
+class EventAnalyzerData<ElectronCandidate, TauCandidate> : public BaseEventAnalyzerData {
+public:
+    using FirstLeg = ElectronCandidate;
+    using SecondLeg = TauCandidate;
+    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
+
+    EventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
+        BaseEventAnalyzerData(eventCategory, _fill_all)
+    {
+        Initialize(eventCategory);
+    }
+
+    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
+                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
+        BaseEventAnalyzerData(outputFile, directoryName, eventCategory, _fill_all, readMode)
+    {
+        Initialize(eventCategory);
+    }
+
+    void Fill(EventInfo& event, double weight)
+    {
+        FillBase(event, weight);
+    }
+
+private:
+    void Initialize(const EventCategory& eventCategory)
+    {
+        static const std::vector<double> res_mva_bins = { -1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
+                                                          0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 };
+        static const std::vector<double> boosted_mva_bins = { -1, 0.6, 0.8, 1 };
+
+        auto mva_bins = &res_mva_bins;
+        auto mva_draw_sf = 1.2;
+        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
+            mva_bins = &boosted_mva_bins;
+            mva_draw_sf = 2;
+        }
+
+        mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
+    }
+};
+
+template<>
+class EventAnalyzerData<MuonCandidate, TauCandidate> : public BaseEventAnalyzerData {
+public:
+    using FirstLeg = MuonCandidate;
+    using SecondLeg = TauCandidate;
+    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
+
+    EventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
+        BaseEventAnalyzerData(eventCategory, _fill_all)
+    {
+        Initialize(eventCategory);
+    }
+
+    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
+                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
+        BaseEventAnalyzerData(outputFile, directoryName, eventCategory, _fill_all, readMode)
+    {
+        Initialize(eventCategory);
+    }
+
+    void Fill(EventInfo& event, double weight)
+    {
+        FillBase(event, weight);
+    }
+
+private:
+    void Initialize(const EventCategory& eventCategory)
+    {
+        static const std::vector<double> res_mva_bins = { -1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
+                                                          0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 1 };
+        static const std::vector<double> boosted_mva_bins = { -1, 0.6, 0.8, 0.9, 1 };
+
+        auto mva_bins = &res_mva_bins;
+        auto mva_draw_sf = 1.2;
+        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
+            mva_bins = &boosted_mva_bins;
+            mva_draw_sf = 2;
+        }
+
+        mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
     }
 };
 
@@ -222,11 +306,11 @@ public:
 private:
     void Initialize(const EventCategory& eventCategory)
     {
-        static const std::vector<double> res1b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
+        static const BinVector res1b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
                                                             0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 };
-        static const std::vector<double> res2b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.2, 0.6, 0.7, 0.8, 0.9,
+        static const BinVector res2b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.2, 0.6, 0.7, 0.8, 0.9,
                                                             1 };
-        static const std::vector<double> boosted_mva_bins = { -1, 0.6, 0.8, 1 };
+        static const BinVector boosted_mva_bins = { -1, 0.6, 0.8, 1 };
 
         auto mva_bins = &res1b_mva_bins;
         auto mva_draw_sf = 1.2;
@@ -240,6 +324,5 @@ private:
         mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
     }
 };
-
 
 } // namespace analysis

--- a/Analysis/include/MvaVariables.h
+++ b/Analysis/include/MvaVariables.h
@@ -196,7 +196,7 @@ public:
         VAR("MT_l1l2", Calculate_MT(leptons, event.pfMET_p4));
         VAR("MT_tot", Calculate_TotalMT(event.p4_1,event.p4_2,event.pfMET_p4)); //Total transverse mass
         VAR("MT2", std::min(Calculate_MT2(event.p4_1, event.p4_2, event.jets_p4[0], event.jets_p4[1], event.pfMET_p4), Calculate_MT2(event.p4_1, event.p4_2, event.jets_p4[1], event.jets_p4[0], event.pfMET_p4))); //Stransverse mass
-        VAR("mass_htautau", ROOT::Math::VectorUtil::InvariantMass(bb,event.SVfit_p4));
+        VAR("mass_H", ROOT::Math::VectorUtil::InvariantMass(bb,event.SVfit_p4));
         VAR("mass_top1", four_bodies::Calculate_topPairMasses(event.p4_1, event.p4_2, event.jets_p4[0], event.jets_p4[1], event.pfMET_p4).first);
         VAR("mass_top2", four_bodies::Calculate_topPairMasses(event.p4_1, event.p4_2, event.jets_p4[0], event.jets_p4[1], event.pfMET_p4).second);
         VAR("MX", four_bodies::Calculate_MX(event.p4_1, event.p4_2, event.jets_p4[0], event.jets_p4[1], event.pfMET_p4));


### PR DESCRIPTION
- Added support of long bit containers in EventSubCategory.
- Fixed mva_score and MT2 binning in all 3 channels to avoid high stat fluctuations or empty bins in background estimation.
- Fixed variable name in MvaVariables.