### PR TITLE
Introduced AnaTuple and precompiled headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CMakeLists.txt.user*
 __init__.py
 *.swp
 .DS_Store
+*.h.pch

--- a/Analysis/config/histograms.cfg
+++ b/Analysis/config/histograms.cfg
@@ -1,0 +1,90 @@
+m_ttbb: x_bins="250 260 270 280 290 300 325 350 375 400 425 450 475 500 550 600 650 700 850 1000" \
+        x_title="M_{#tau#tau+jj} (GeV)" y_title="dN/dm_{#tau#tau+jj} (1/GeV)" max_y_sf=1.5
+m_ttbb_kinfit: x_bins="250 260 270 280 290 300 325 350 375 400 425 450 475 500 550 600 650 700 850 1000" \
+               x_title="M_{H}^{kinfit} (GeV)" y_title="dN/dm_{H}^{kinfit} (1/GeV)" max_y_sf=1.4
+m_sv: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" \
+      x_title="M_{#tau#tau} (GeV)" y_title="dN/dm_{#tau#tau} (1/GeV)" max_y_sf=1.6
+
+MT2: x_bins="0 25 50 75 100 125 150 175 200 250 300 500" \
+     x_title="MT2_{H} (GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+MT2/boosted: x_bins="0 150 200 250 300 500" x_title="MT2_{H} (GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+
+mva_score: x_range=-1:1/40 x_title="MVA score" y_title="Events" log_y=true max_y_sf=1.8
+mva_score/eTau: x_bins="-1 -0.9 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1" \
+                x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.2
+mva_score/eTau/2jets2LoosebtagB: x_bins="-1 0.6 0.8 1" x_title="MVA score" y_title="dN / bin width" \
+                                 log_y=false max_y_sf=2
+mva_score/muTau: x_bins="-1 -0.9 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.85 0.9 \
+                         0.95 1" \
+                 x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.2
+mva_score/muTau/2jets2LoosebtagB: x_bins="-1 0.6 0.8 0.9 1" x_title="MVA score" y_title="dN / bin width" \
+                                  log_y=false max_y_sf=2
+mva_score/tauTau: x_bins="-1 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1" \
+                  x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.4
+mva_score/tauTau/2jets2btagR: x_bins="-1 -0.8 -0.6 -0.3 0.1 0.4 0.7 0.85 1" \
+                        x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.4
+mva_score/tauTau/2jets2LoosebtagB: x_bins="-1 0 0.6 0.8 1" x_title="MVA score" y_title="dN / bin width" \
+                                   log_y=false max_y_sf=2
+
+
+mt_tot: x_range=0:500/25 x_title="M_{T}^{TOT}(GeV)" y_title="Events" max_y_sf=1.5
+deta_hbbhtautau: x_range=-5:5/25 x_title="#Delta#eta_{#tau#tau, jj}" y_title="Events" max_y_sf=1.8
+dphi_hbbhtautau: x_range=-4:4/20 x_title="#Delta#phi(#tau#tau, jj)" y_title="Events" max_y_sf=1.4
+MT_htautau: x_range=0:250/20 x_title="M_{T}^{#tau#tau}(GeV)" y_title="Events" max_y_sf=1.4
+
+m_tt_vis: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" x_title="M_{vis}(GeV)" \
+          y_title="dN/dm (1/GeV)" max_y_sf=1.6
+pt_H_tt: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+pt_H_tt_MET: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(GeV)" \
+             y_title="dN/dm (1/GeV)" max_y_sf=1.5
+pt_1: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(leading#tau_{h})(GeV)" \
+      y_title="dN/dm (1/GeV)" max_y_sf=1.6
+eta_1: x_range=-2.5:2.5/20 x_title="#eta(leading#tau_{h})" y_title="Events" max_y_sf=1.6
+iso_1: x_range=0:10/100 x_title="Iso#tau_{1}" y_title="Events"
+mt_1: x_range=0:200/20 x_title="M_{T}1(GeV)" y_title="Events" max_y_sf=1.3
+pt_2: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(subleading#tau_{h})(GeV)" \
+      y_title="dN/dm (1/GeV)" max_y_sf=1.6
+eta_2: x_range=-2.5:2.5/20 x_title="#eta(subleading#tau_{h})" y_title="Events" max_y_sf=1.6
+iso_2: x_range=0:10/100 x_title="Iso#tau_{2}" y_title="Events"
+mt_2: x_range=0:200/20 x_title="M_{T}2(GeV)" y_title="Events" max_y_sf=1.3
+dR_l1l2: x_range=0:4/20 x_title="#DeltaR(#tau#tau)" y_title="Events" max_y_sf=1.6
+abs_dphi_l1MET: x_range=0:3.2/20 x_title="|#Delta#phi(leading#tau_{h}, miss)|" y_title="Events" max_y_sf=1.4
+dphi_htautauMET: x_range=-4:4/25 x_title="#Delta#phi(#tau#tau, miss)" y_title="Events" max_y_sf=1.4
+dR_l1l2MET: x_range=0:6/20 x_title="#Delta R(leading#tau_{h}+subleading#tau_{h}, miss)" y_title="Events" max_y_sf=1.4
+dR_l1l2Pt_htautau: x_range=0:500/20 x_title="#DeltaR (leading#tau_{h},subleading#tau_{h}) P_{T}(#tau#tau) (GeV)" \
+                   y_title="Events" max_y_sf=1.4
+mass_l1l2MET: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" \
+              x_title="M_{leading#tau_{h}+subleading#tau_{h}+miss}" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+pt_l1l2MET: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" \
+            x_title="P_{T}(leading#tau_{h}+subleading#tau_{h}+miss) (GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+
+npv: x_range=0:40/40 x_title="Number of Primary Vertex" y_title="Events" max_y_sf=1.4
+MET: x_range=0:200/25 x_title="E_{T}^{miss}(GeV)" y_title="Events" max_y_sf=1.4
+phiMET: x_range=0:3.2/20 x_title="#phi_{E_{T}^{miss}}" y_title="Events" max_y_sf=1.5
+pt_MET: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}^{miss} (GeV)" \
+        y_title="dN/dm (1/GeV)" max_y_sf=1.6
+
+m_bb: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" x_title="M_{jj} (GeV)" \
+      y_title="dN/dm (1/GeV)" max_y_sf=1.6
+pt_H_bb: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+pt_b1: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="Leading selected jet p_{T} (GeV)" \
+       y_title="dN/dm (1/GeV)" max_y_sf=1.4
+eta_b1: x_range=-2.5:2.5/20 x_title="Leading selected jet #eta" y_title="Events" max_y_sf=1.6
+csv_b1: x_range=0.8:1/20 x_title="Leading selected jet CSV" y_title="Events" max_y_sf=1.4
+pt_b2: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="Subleading selected jet p_{T} (GeV)" \
+       y_title="dN/dm (1/GeV)" max_y_sf=1.4
+eta_b2: x_range=-2.5:2.5/20 x_title="Subleading selected jet #eta" y_title="Events" max_y_sf=1.6
+csv_b2: x_range=0:1/40 x_title="Subleading selected jet CSV" y_title="Events" max_y_sf=1.4
+costheta_METhbb: x_range=-1:1/20 x_title="#cos #theta(jj, miss)" y_title="Events" max_y_sf=1.4
+
+dR_b1b2: x_range=0:5/25 x_title="#DeltaR_{jj}" y_title="Events" max_y_sf=1.5
+dR_b1b2_boosted: x_range=3:8/25 x_title="Boosted #Delta R_{jj}" y_title="Events" max_y_sf=1.4
+HT_otherjets: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" x_title="HT other jets (GeV)" \
+              y_title="dN/dm (1/GeV)" max_y_sf=1.4
+
+mass_top1: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" x_title="mass top_1 (GeV)" \
+           y_title="dN/dm (1/GeV)" max_y_sf=1.4
+mass_top2: x_bins="10 30 50 75 90 105 120 135 150 175 210 250 300 350 400 500" x_title="mass top_2 (GeV)" \
+           y_title="dN/dm (1/GeV)" max_y_sf=1.4
+p_zeta: x_range=-50:250/30 x_title="p_{#zeta}" y_title="Events" max_y_sf=1.4
+p_zetavisible: x_range=0:200/25 x_title="p_{#zeta}^{vis}" y_title="Events" max_y_sf=1.4

--- a/Analysis/config/sources.cfg
+++ b/Analysis/config/sources.cfg
@@ -6,6 +6,7 @@ energy_scales: all
 limit_category: 2jets1btagR res1b
 limit_category: 2jets2btagR res2b
 limit_category: 2jets2LoosebtagB boosted
+hist_cfg: hh-bbtautau/Analysis/config/histograms.cfg
 
 [ANA_DESC full : common]
 signals: Signal_Radion Signal_Graviton Signal_SM

--- a/Analysis/include/AnaTuple.h
+++ b/Analysis/include/AnaTuple.h
@@ -1,0 +1,293 @@
+/*! Definition of a containers that store analyzers output.
+This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
+
+#pragma once
+
+#include "AnalysisTools/Core/include/SmartTree.h"
+#include "AnalysisTools/Core/include/AnalysisMath.h"
+#include "EventAnalyzerDataId.h"
+
+namespace analysis {
+
+#define CREATE_VAR(r, type, name) VAR(type, name)
+#define VAR_LIST(type, ...) BOOST_PP_SEQ_FOR_EACH(CREATE_VAR, type, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+#define ANA_EVENT_DATA() \
+    VAR(std::vector<uint32_t>, dataIds) /* EventAnalyzerDataId */ \
+    VAR(std::vector<double>, all_weights) /* all weight */ \
+    VAR(std::vector<float>, all_mva_scores) /* all mva scores */ \
+    VAR(bool, has_2jets) /* has 2 jets */ \
+    VAR(double, weight) /* weight */ \
+    VAR(float, mva_score) /* mva score */ \
+    VAR_LIST(float, m_ttbb, m_ttbb_kinfit, m_sv, MT2, mt_tot, deta_hbbhtautau, dphi_hbbhtautau, m_tt_vis, pt_H_tt, \
+             pt_H_tt_MET, pt_1, eta_1, iso_1, mt_1, pt_2, eta_2, iso_2, mt_2, dR_l1l2, abs_dphi_l1MET, \
+             dphi_htautauMET, dR_l1l2MET, dR_l1l2Pt_htautau, mass_l1l2MET, pt_l1l2MET, MT_htautau, npv, MET, phiMET, \
+             pt_MET, m_bb, pt_H_bb, pt_b1, eta_b1, csv_b1, pt_b2, eta_b2, csv_b2, costheta_METhbb, dR_b1b2, \
+             dR_b1b2_boosted, HT_otherjets, mass_top1, mass_top2, p_zeta, p_zetavisible) \
+    /**/
+
+#define VAR(type, name) DECLARE_BRANCH_VARIABLE(type, name)
+DECLARE_TREE(bbtautau, AnaEvent, AnaTuple, ANA_EVENT_DATA, "events")
+#undef VAR
+
+#define VAR(type, name) ADD_DATA_TREE_BRANCH(name)
+INITIALIZE_TREE(bbtautau, AnaTuple, ANA_EVENT_DATA)
+#undef VAR
+#undef ANA_EVENT_DATA
+#undef VAR_LIST
+#undef CREATE_VAR
+
+#define ANA_AUX_DATA() \
+    VAR(std::vector<uint32_t>, dataIds) /* EventAnalyzerDataId code */ \
+    VAR(std::vector<std::string>, dataId_names) /* EventAnalyzerDataId name */ \
+    /**/
+
+#define VAR(type, name) DECLARE_BRANCH_VARIABLE(type, name)
+DECLARE_TREE(bbtautau, AnaAux, AnaAuxTuple, ANA_AUX_DATA, "aux")
+#undef VAR
+
+#define VAR(type, name) ADD_DATA_TREE_BRANCH(name)
+INITIALIZE_TREE(bbtautau, AnaAuxTuple, ANA_AUX_DATA)
+#undef VAR
+#undef ANA_AUX_DATA
+
+namespace bbtautau {
+class AnaTupleWriter {
+public:
+    using DataId = EventAnalyzerDataId;
+    using DataIdBiMap = boost::bimap<DataId, uint32_t>;
+    using DataIdMap = std::map<DataId, std::tuple<double, double>>;
+
+    AnaTupleWriter(const std::string& file_name, Channel channel) :
+        file(root_ext::CreateRootFile(file_name)), tuple(ToString(channel), file.get(), false),
+        aux_tuple(file.get(), false)
+    {
+    }
+
+    ~AnaTupleWriter()
+    {
+        for(const auto& id : known_data_ids.left) {
+            aux_tuple().dataIds.push_back(id.second);
+            aux_tuple().dataId_names.push_back(id.first.GetName());
+        }
+        aux_tuple.Fill();
+        aux_tuple.Write();
+        tuple.Write();
+    }
+
+    template<typename EventInfo>
+    void AddEvent(EventInfo& event, const DataIdMap& dataIds)
+    {
+        using namespace ROOT::Math::VectorUtil;
+        static constexpr float def_val = std::numeric_limits<float>::lowest();
+
+        if(!dataIds.size()) return;
+        for(const auto& entry : dataIds) {
+            if(!known_data_ids.left.count(entry.first)) {
+                const uint32_t hash = tools::hash(entry.first.GetName());
+                if(known_data_ids.right.count(hash))
+                    throw exception("Duplicated hash for event id '%1%' and '%2%'.") % entry.first
+                        %  known_data_ids.right.at(hash);
+                known_data_ids.insert({entry.first, hash});
+            }
+            tuple().dataIds.push_back(known_data_ids.left.at(entry.first));
+            tuple().all_weights.push_back(std::get<0>(entry.second));
+            tuple().all_mva_scores.push_back(static_cast<float>(std::get<1>(entry.second)));
+        }
+
+        tuple().weight = def_val;
+        tuple().mva_score = def_val;
+        tuple().has_2jets = event.HasBjetPair();
+        tuple().m_sv = event.GetHiggsTTMomentum(true).M();
+
+        if(event.HasBjetPair()) {
+            tuple().m_ttbb = event.GetResonanceMomentum(true, false).M();
+            const auto& kinfit = event.GetKinFitResults();
+            tuple().m_ttbb_kinfit = kinfit.HasValidMass() ? kinfit.mass : def_val;
+            tuple().MT2 = event.GetMT2();
+        } else {
+            tuple().m_ttbb = def_val;
+            tuple().m_ttbb_kinfit = def_val;
+            tuple().MT2 = def_val;
+        }
+
+        const auto& Htt = event.GetHiggsTTMomentum(false);
+        const auto& t1 = event.GetLeg(1);
+        const auto& t2 = event.GetLeg(2);
+
+        tuple().m_tt_vis = Htt.M();
+        tuple().pt_H_tt = Htt.Pt();
+        tuple().pt_H_tt_MET = (Htt + event.GetMET().GetMomentum()).Pt();
+        tuple().pt_1 = t1.GetMomentum().pt();
+        tuple().eta_1 = t1.GetMomentum().eta();
+        tuple().iso_1 = t1.GetIsolation();
+        tuple().mt_1 = Calculate_MT(t1.GetMomentum(), event.GetMET().GetMomentum());
+        tuple().pt_2 = t2.GetMomentum().pt();
+        tuple().eta_2 = t2.GetMomentum().eta();
+        tuple().iso_2 = t2.GetIsolation();
+        tuple().mt_2 = Calculate_MT(t2.GetMomentum(), event.GetMET().GetMomentum());
+        tuple().dR_l1l2 = DeltaR(t1.GetMomentum(),t2.GetMomentum());
+        tuple().abs_dphi_l1MET = std::abs(DeltaPhi(t1.GetMomentum(), event.GetMET().GetMomentum()));
+        tuple().dphi_htautauMET = DeltaPhi(event.GetHiggsTTMomentum(true), event.GetMET().GetMomentum());
+        tuple().dR_l1l2MET = DeltaR(event.GetHiggsTTMomentum(false), event.GetMET().GetMomentum());
+        tuple().dR_l1l2Pt_htautau = DeltaR(t1.GetMomentum(), t2.GetMomentum()) * event.GetHiggsTTMomentum(true).pt();
+        tuple().mass_l1l2MET = (event.GetHiggsTTMomentum(false) + event.GetMET().GetMomentum()).M();
+        tuple().pt_l1l2MET = (event.GetHiggsTTMomentum(false) + event.GetMET().GetMomentum()).pt();
+        tuple().MT_htautau = Calculate_MT(event.GetHiggsTTMomentum(true), event.GetMET().GetMomentum());
+        tuple().npv = event->npv;
+        tuple().MET = event.GetMET().GetMomentum().Pt();
+        tuple().phiMET = event.GetMET().GetMomentum().Phi();
+        tuple().pt_MET = event.GetMET().GetMomentum().pt();
+        tuple().p_zeta = Calculate_Pzeta(t1.GetMomentum(), t2.GetMomentum(),  event.GetMET().GetMomentum());
+        tuple().p_zetavisible = Calculate_visiblePzeta(t1.GetMomentum(), t2.GetMomentum());
+        tuple().mt_tot = Calculate_TotalMT(t1.GetMomentum(),t2.GetMomentum(),event.GetMET().GetMomentum());
+        tuple().HT_otherjets = event->ht_other_jets;
+
+        if(event.HasBjetPair()) {
+            const auto& Hbb = event.GetHiggsBB();
+            const auto& b1 = Hbb.GetFirstDaughter();
+            const auto& b2 = Hbb.GetSecondDaughter();
+            tuple().m_bb = Hbb.GetMomentum().M();
+            tuple().pt_H_bb = Hbb.GetMomentum().Pt();
+            tuple().pt_b1 = b1.GetMomentum().pt();
+            tuple().eta_b1 = b1.GetMomentum().Eta();
+            tuple().csv_b1 = b1->csv();
+            tuple().pt_b2 = b2.GetMomentum().Pt();
+            tuple().eta_b2 = b2.GetMomentum().Eta();
+            tuple().csv_b2 = b2->csv();
+            tuple().dphi_hbbhtautau = DeltaPhi(Hbb.GetMomentum(), event.GetHiggsTTMomentum(true));
+            tuple().deta_hbbhtautau = (Hbb.GetMomentum()-event.GetHiggsTTMomentum(true)).Eta();
+            tuple().costheta_METhbb = four_bodies::Calculate_cosTheta_2bodies(event.GetMET().GetMomentum(),
+                                                                              Hbb.GetMomentum());
+            tuple().dR_b1b2 = DeltaR(b1.GetMomentum(), b2.GetMomentum());
+            tuple().dR_b1b2_boosted = four_bodies::Calculate_dR_boosted(b1.GetMomentum(), b2.GetMomentum(),
+                                                                        Hbb.GetMomentum());
+
+            tuple().mass_top1 = four_bodies::Calculate_topPairMasses(t1.GetMomentum(), t2.GetMomentum(),
+                                                                     b1.GetMomentum(), b2.GetMomentum(),
+                                                                     event.GetMET().GetMomentum()).first;
+            tuple().mass_top2 = four_bodies::Calculate_topPairMasses(t1.GetMomentum(), t2.GetMomentum(),
+                                                                     b1.GetMomentum(), b2.GetMomentum(),
+                                                                     event.GetMET().GetMomentum()).second;
+        } else {
+            tuple().m_bb = def_val;
+            tuple().pt_H_bb = def_val;
+            tuple().pt_b1 = def_val;
+            tuple().eta_b1 = def_val;
+            tuple().csv_b1 = def_val;
+            tuple().pt_b2 = def_val;
+            tuple().eta_b2 = def_val;
+            tuple().csv_b2 = def_val;
+            tuple().dphi_hbbhtautau = def_val;
+            tuple().deta_hbbhtautau = def_val;
+            tuple().costheta_METhbb = def_val;
+            tuple().dR_b1b2 = def_val;
+            tuple().dR_b1b2_boosted = def_val;
+            tuple().mass_top1 = def_val;
+            tuple().mass_top2 = def_val;
+        }
+
+        tuple.Fill();
+    }
+
+private:
+    std::shared_ptr<TFile> file;
+    AnaTuple tuple;
+    AnaAuxTuple aux_tuple;
+    DataIdBiMap known_data_ids;
+};
+
+class AnaTupleReader {
+public:
+    using DataId = EventAnalyzerDataId;
+    using Hash = uint32_t;
+    using DataIdBiMap = boost::bimap<DataId, Hash>;
+    using DataIdMap = std::map<DataId, std::tuple<double, double>>;
+    using NameSet = std::set<std::string>;
+
+    AnaTupleReader(const std::string& file_name, Channel channel, NameSet& active_var_names) :
+        file(root_ext::OpenRootFile(file_name))
+    {
+        static const NameSet essential_branches = { "dataIds", "all_weights", "has_2jets" };
+        static const NameSet other_branches = { "all_mva_scores", "weight" };
+        NameSet enabled_branches;
+        if(active_var_names.size()) {
+            enabled_branches.insert(essential_branches.begin(), essential_branches.end());
+            enabled_branches.insert(active_var_names.begin(), active_var_names.end());
+            if(active_var_names.count("mva_score"))
+                enabled_branches.insert("all_mva_scores");
+
+        } else {
+            enabled_branches = ExtractAllBranchNames(channel);
+            for(const auto& name : enabled_branches) {
+                if(!essential_branches.count(name) && !other_branches.count(name))
+                    active_var_names.insert(name);
+            }
+        }
+        tuple = std::make_shared<AnaTuple>(ToString(channel), file.get(), true, NameSet(), enabled_branches);
+
+        AnaAuxTuple aux_tuple(file.get(), true);
+        aux_tuple.GetEntry(0);
+        ExtractDataIds(aux_tuple());
+    }
+
+    const DataId& GetDataIdByHash(Hash hash) const
+    {
+        const auto iter = known_data_ids.right.find(hash);
+        if(iter == known_data_ids.right.end())
+            throw exception("EventAnalyzerDataId not found for hash = %1%") % hash;
+        return iter->second;
+    }
+
+    const DataId& GetDataIdByIndex(size_t dataId_index) const
+    {
+        if(dataId_index >= (*tuple)().dataIds.size())
+            throw exception("DataId index is out of range.");
+        return GetDataIdByHash((*tuple)().dataIds.at(dataId_index));
+    }
+
+    AnaTuple& GetAnaTuple() { return *tuple; }
+
+    void UpdateSecondaryBranches(size_t dataId_index)
+    {
+        if(dataId_index >= (*tuple)().dataIds.size())
+            throw exception("DataId index is out of range.");
+        if(dataId_index >= (*tuple)().all_weights.size())
+            throw exception("Inconsistent AnaTuple entry.");
+        (*tuple)().weight = (*tuple)().all_weights.at(dataId_index);
+        (*tuple)().mva_score = dataId_index < (*tuple)().all_mva_scores.size()
+                             ? (*tuple)().all_mva_scores.at(dataId_index) : 0;
+    }
+
+private:
+    void ExtractDataIds(const AnaAux& aux)
+    {
+        const size_t N = aux.dataIds.size();
+        if(aux.dataId_names.size() != N)
+            throw exception("Inconsistent dataId info in AnaAux tuple.");
+        for(size_t n = 0; n < N; ++n) {
+            const auto hash = aux.dataIds.at(n);
+            const auto& dataId_name = aux.dataId_names.at(n);
+            const auto dataId = DataId::Parse(dataId_name);
+            if(known_data_ids.right.count(hash))
+                throw exception("Duplicated hash = %1% for in AnaAux tuple.") % hash;
+            if(known_data_ids.left.count(dataId))
+                throw exception("Duplicated dataId = '%1%' for in AnaAux tuple.") % dataId_name;
+            known_data_ids.insert({dataId, hash});
+        }
+    }
+
+    NameSet ExtractAllBranchNames(Channel channel) const
+    {
+        AnaTuple tmpTuple(ToString(channel), file.get(), true);
+        return tmpTuple.GetActiveBranches();
+    }
+
+private:
+    std::shared_ptr<TFile> file;
+    std::shared_ptr<AnaTuple> tuple;
+    DataIdBiMap known_data_ids;
+    NameSet var_branch_names;
+};
+} // namespace bbtautau
+} // namespace analysis

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -9,41 +9,33 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 #include "h-tautau/Cuts/include/Btag_2016.h"
 #include "h-tautau/Cuts/include/hh_bbtautau_2016.h"
 #include "h-tautau/Analysis/include/EventLoader.h"
-#include "StackedPlotsProducer.h"
-#include "LimitsInputProducer.h"
 #include "MvaReader.h"
+#include "EventAnalyzerData.h"
+#include "AnaTuple.h"
+#include "EventAnalyzerCore.h"
 
 namespace analysis {
 
-struct AnalyzerArguments {
-    REQ_ARG(std::string, setup);
-    REQ_ARG(std::string, sources);
+struct AnalyzerArguments : CoreAnalyzerArguments {
     REQ_ARG(std::string, input);
     REQ_ARG(std::string, output);
-    OPT_ARG(std::string, mva_setup, "");
-    OPT_ARG(bool, draw, true);
-    OPT_ARG(bool, saveFullOutput, false);
     OPT_ARG(unsigned, event_set, 0);
-    OPT_ARG(unsigned, n_threads, 1);
 };
 
 template<typename _FirstLeg, typename _SecondLeg>
-class BaseEventAnalyzer {
+class BaseEventAnalyzer : public EventAnalyzerCore {
 public:
     using FirstLeg = _FirstLeg;
     using SecondLeg = _SecondLeg;
     using Event = ntuple::Event;
     using EventPtr = std::shared_ptr<Event>;
     using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-    using AnaData = ::analysis::EventAnalyzerData<FirstLeg, SecondLeg>;
-    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection<AnaData>;
-    using PlotsProducer = ::analysis::StackedPlotsProducer<FirstLeg, SecondLeg>;
 
     static constexpr Channel ChannelId() { return ChannelInfo::IdentifyChannel<FirstLeg, SecondLeg>(); }
-    static const std::string& ChannelNameLatex() { return __Channel_names_latex.EnumToString(ChannelId()); }
 
     static EventCategorySet DetermineEventCategories(EventInfo& event)
     {
+
         static const std::map<DiscriminatorWP, double> btag_working_points = {
             { DiscriminatorWP::Loose, cuts::btag_2016::CSVv2L },
             { DiscriminatorWP::Medium, cuts::btag_2016::CSVv2M }
@@ -76,120 +68,22 @@ public:
         return categories;
     }
 
-    BaseEventAnalyzer(const AnalyzerArguments& _args)
-        : args(_args), anaDataCollection(args.output() + "_full.root", args.saveFullOutput())
+    BaseEventAnalyzer(const AnalyzerArguments& _args) :
+        EventAnalyzerCore(_args, ChannelId()), args(_args), anaTupleWriter(args.output(), ChannelId())
     {
-        ROOT::EnableThreadSafety();
-        if(args.n_threads() > 1)
-            ROOT::EnableImplicitMT(args.n_threads());
-
-        ConfigReader config_reader;
-
-        AnalyzerSetupCollection ana_setup_collection;
-        AnalyzerConfigEntryReader ana_entry_reader(ana_setup_collection);
-        config_reader.AddEntryReader("ANA_DESC", ana_entry_reader, false);
-
-        MvaReaderSetupCollection mva_setup_collection;
-        MvaReaderSetupEntryReader mva_entry_reader(mva_setup_collection);
-        config_reader.AddEntryReader("MVA", mva_entry_reader, false);
-
-        SampleDescriptorConfigEntryReader sample_entry_reader(sample_descriptors);
-        config_reader.AddEntryReader("SAMPLE", sample_entry_reader, true);
-
-        CombinedSampleDescriptorConfigEntryReader combined_entry_reader(cmb_sample_descriptors, sample_descriptors);
-        config_reader.AddEntryReader("SAMPLE_CMB", combined_entry_reader, false);
-
-        config_reader.ReadConfig(args.sources());
-
-        if(!ana_setup_collection.count(args.setup()))
-            throw exception("Setup '%1%' not found in the configuration file '%2%'.") % args.setup() % args.sources();
-        ana_setup = ana_setup_collection.at(args.setup());
-
-        if(args.mva_setup().size()) {
-            if(!mva_setup_collection.count(args.mva_setup()))
-                throw exception("MVA setup '%1%' not found.") % args.mva_setup();
-            mva_setup = mva_setup_collection.at(args.mva_setup());
-        }
-        RemoveUnusedSamples();
-
-        CreateEventSubCategoriesToProcess();
         InitializeMvaReader();
     }
-
-    virtual ~BaseEventAnalyzer() {}
 
     void Run()
     {
         ProcessSamples(ana_setup.signals, "signal");
         ProcessSamples(ana_setup.data, "data");
         ProcessSamples(ana_setup.backgrounds, "background");
-        ProcessCombinedSamples(ana_setup.cmb_samples);
-
-        std::cout << "Producing inputs for limits..." << std::endl;
-        LimitsInputProducer<FirstLeg, SecondLeg> limitsInputProducer(anaDataCollection, sample_descriptors,
-                                                                     cmb_sample_descriptors);
-        for(const std::string& hist_name : ana_setup.final_variables) {
-            for(const auto& subCategory : EventSubCategoriesToProcess()) {
-                std::cout << '\t' << hist_name << "/" << subCategory << std::endl;
-                limitsInputProducer.Produce(args.output(), hist_name, ana_setup.limit_categories, subCategory,
-                                            ana_setup.energy_scales, EventRegionsToProcess());
-            }
-        }
-
-        if(args.draw()) {
-            std::cout << "Creating plots..." << std::endl;
-            const auto samplesToDraw = PlotsProducer::CreateOrderedSampleCollection(
-                        ana_setup.draw_sequence, sample_descriptors, cmb_sample_descriptors, ana_setup.signals,
-                        ana_setup.data);
-            PlotsProducer plotsProducer(anaDataCollection, samplesToDraw, false, true);
-            std::set<std::string> signal_names(ana_setup.signals.begin(), ana_setup.signals.end());
-            plotsProducer.PrintStackedPlots(args.output(), EventRegion::SignalRegion(), EventCategoriesToProcess(),
-                                            EventSubCategoriesToProcess(), signal_names);
-        }
-
         std::cout << "Saving output file..." << std::endl;
     }
 
 protected:
     virtual EventRegion DetermineEventRegion(EventInfo& event, EventCategory eventCategory) = 0;
-    virtual const EventCategorySet& EventCategoriesToProcess() const
-    {
-        static const EventCategorySet categories = {
-            EventCategory::TwoJets_Inclusive(), EventCategory::TwoJets_ZeroBtag_Resolved(),
-            EventCategory::TwoJets_OneBtag_Resolved(), /*EventCategory::TwoJets_OneLooseBtag(),*/
-            EventCategory::TwoJets_TwoBtag_Resolved(), /*EventCategory::TwoJets_TwoLooseBtag()*/
-            EventCategory::TwoJets_TwoLooseBtag_Boosted()
-        };
-        return categories;
-    }
-
-    virtual const EventSubCategorySet& EventSubCategoriesToProcess() const { return sub_categories_to_process; }
-
-    virtual const EventRegionSet& EventRegionsToProcess() const
-    {
-        static const EventRegionSet regions = {
-            EventRegion::OS_Isolated(), EventRegion::OS_AntiIsolated(),
-            EventRegion::SS_Isolated(), EventRegion::SS_AntiIsolated(),
-            EventRegion::SS_LooseIsolated()
-        };
-        return regions;
-    }
-
-    void CreateEventSubCategoriesToProcess()
-    {
-        const auto base = EventSubCategory().SetCutResult(SelectionCut::mh, true);
-        sub_categories_to_process.insert(base);
-        if(mva_setup.is_initialized()) {
-            for(const auto& mva_sel : mva_setup->selections) {
-                auto param = mva_sel.second;
-                std::cout<<"Selection cut: "<<mva_sel.first<<" - name: "<<param.name
-                        <<" spin: "<<param.spin<<" mass: "<<param.mass<<" cut: "<<param.cut<<std::endl;
-                auto sub_category = EventSubCategory(base).SetCutResult(mva_sel.first, true);
-                sub_categories_to_process.insert(sub_category);
-
-            }
-        }
-    }
 
     void InitializeMvaReader()
     {
@@ -240,7 +134,6 @@ protected:
         return sub_category;
     }
 
-
     void ProcessSamples(const std::vector<std::string>& sample_names, const std::string& sample_set_name)
     {
         std::cout << "Processing " << sample_set_name << " samples... " << std::endl;
@@ -249,14 +142,10 @@ protected:
             if(!sample_descriptors.count(sample_name))
                 throw exception("Sample '%1%' not found.") % sample_name;
             SampleDescriptor& sample = sample_descriptors.at(sample_name);
-            if(sample.channels.size() && !sample.channels.count(ChannelId())) continue;
-            std::cout << '\t' << sample.name << std::endl;
-            if(sample.sampleType == SampleType::QCD) {
-                if(sample_index != sample_names.size() - 1)
-                    throw exception("QCD sample should be the last in the background list.");
-                EstimateQCD(sample);
+            if(sample.sampleType == SampleType::QCD || (sample.channels.size() && !sample.channels.count(ChannelId())))
                 continue;
-            }
+            std::cout << '\t' << sample.name << std::endl;
+
             std::set<std::string> processed_files;
             for(const auto& sample_wp : sample.working_points) {
                 if(!sample_wp.file_path.size() || processed_files.count(sample_wp.file_path)) continue;
@@ -293,6 +182,7 @@ protected:
             EventInfo event(tupleEvent, ntuple::JetPair{0, 1}, &summary);
             if(!ana_setup.energy_scales.count(event.GetEnergyScale())) continue;
 
+            bbtautau::AnaTupleWriter::DataIdMap dataIds;
             const auto eventCategories = DetermineEventCategories(event);
             for(auto eventCategory : eventCategories) {
                 if (!EventCategoriesToProcess().count(eventCategory)) continue;
@@ -312,149 +202,25 @@ protected:
                         const EventAnalyzerDataId anaDataId(eventCategory, subCategory, region,
                                                             event.GetEnergyScale(), sample_wp.full_name);
                         if(sample.sampleType == SampleType::Data) {
-                            ProcessDataEvent(anaDataId, event);
+                            dataIds[anaDataId] = std::make_tuple(1., mva_score);
                         } else {
                             const double weight = event->weight_total * sample.cross_section * ana_setup.int_lumi
                                                 / summary->totalShapeWeight;
-                            if(sample.sampleType == SampleType::MC)
-                                anaDataCollection.Fill(anaDataId, event, weight);
-                            else
-                                ProcessSpecialEvent(sample, sample_wp, anaDataId, event, weight);
+                            if(sample.sampleType == SampleType::MC) {
+                                dataIds[anaDataId] = std::make_tuple(weight, mva_score);
+                            } else
+                                ProcessSpecialEvent(sample, sample_wp, anaDataId, event, weight, dataIds);
                         }
+                        anaTupleWriter.AddEvent(event, dataIds);
                     }
                 }
             }
-        }
-    }
-
-    virtual void EstimateQCD(const SampleDescriptor& qcd_sample)
-    {
-        static const EventRegionSet sidebandRegions = {
-            EventRegion::OS_AntiIsolated(), EventRegion::SS_Isolated(), EventRegion::SS_AntiIsolated(),
-            EventRegion::SS_LooseIsolated()
-        };
-        static const EventEnergyScaleSet qcdEnergyScales = { EventEnergyScale::Central };
-
-        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
-                EventSubCategoriesToProcess(), sidebandRegions, qcdEnergyScales)) {
-            const auto qcdAnaDataId = metaDataId.Set(qcd_sample.name);
-            auto& qcdAnaData = anaDataCollection.Get(qcdAnaDataId);
-            for(const auto& sample_name : sample_descriptors) {
-                const SampleDescriptor& sample =  sample_name.second;
-                if(sample.sampleType == SampleType::QCD) continue;
-                if(ana_setup.IsSignal(sample.name)) continue;
-                double factor = sample.sampleType == SampleType::Data ? +1 : -1;
-                for(const auto& sample_wp : sample.working_points) {
-                    const auto anaDataId = metaDataId.Set(sample_wp.full_name);
-                    auto& anaData = anaDataCollection.Get(anaDataId);
-                    for(const auto& sub_entry : anaData.template GetEntriesEx<TH1D>()) {
-                        auto& entry = qcdAnaData.template GetEntryEx<TH1D>(sub_entry.first);
-                        for(const auto& hist : sub_entry.second->GetHistograms()) {
-                            entry(hist.first).Add(hist.second.get(), factor);
-                        }
-                    }
-                }
-            }
-        }
-
-        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
-                EventSubCategoriesToProcess(), qcdEnergyScales)) {
-            const auto anaDataId = metaDataId.Set(qcd_sample.name);
-            auto& osIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_Isolated()));
-            auto& ssIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_Isolated()));
-            auto& ssLooseIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_LooseIsolated()));
-            auto& osAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
-            auto& ssAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
-            for(const auto& sub_entry : ssIsoData.template GetEntriesEx<TH1D>()) {
-                auto& entry_osIso = osIsoData.template GetEntryEx<TH1D>(sub_entry.first);
-                auto& entry_ss_looseIso = ssLooseIsoData.template GetEntryEx<TH1D>(sub_entry.first);
-                auto& entry_osAntiIso = osAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
-                auto& entry_ssAntiIso = ssAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
-                for(const auto& hist : sub_entry.second->GetHistograms()) {
-                    std::string debug_info, negative_bins_info;
-                    if(!HasNegativeContribution(*hist.second,debug_info, negative_bins_info)) continue;
-                    const auto osAntiIso_integral = analysis::Integral(entry_osAntiIso(hist.first), true);
-                    const auto ssAntiIso_integral = analysis::Integral(entry_ssAntiIso(hist.first), true);
-                    if (osAntiIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: OS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
-                        continue;
-                    }
-
-                    if (ssAntiIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: SS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
-                        continue;
-                    }
-                    const double k_factor = osAntiIso_integral.GetValue()/ssAntiIso_integral.GetValue();
-                    const auto ssIso_integral = analysis::Integral(*hist.second, true);
-                    if (ssIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: SS Iso integral less or equal 0 for " << hist.first << std::endl;
-                        continue;
-                    }
-                    const double total_yield = ssIso_integral.GetValue() * k_factor;
-                    entry_osIso(hist.first).CopyContent(entry_ss_looseIso(hist.first));
-                    analysis::RenormalizeHistogram(entry_osIso(hist.first),total_yield,true);
-
-
-                }
-            }
-        }
-    }
-
-    bool HasNegativeContribution(/*const FlatAnalyzerDataMetaId_noRegion_noName& anaDataMetaId,
-                                      EventRegion eventRegion,*/ TH1D& histogram, /*const std::string& current_category,*/
-                                      std::string& debug_info, std::string& negative_bins_info)
-    {
-        static const double correction_factor = 0.0000001;
-
-        std::ostringstream ss_debug;
-
-//        ss_debug << "\nSubtracting background for '" << histogram.GetName() << "' in region " << eventRegion
-//                 << " for Event category '" << anaDataMetaId.eventCategory
-//                 << "' for data category '" << current_category
-//                 << "'.\nInitial integral: " << Integral(histogram, true) << ".\n";
-
-
-        const PhysicalValue original_Integral = Integral(histogram, true);
-        ss_debug << "\nSubtracted hist for '" << histogram.GetName() << ".\n";
-        ss_debug << "Integral after bkg subtraction: " << original_Integral << ".\n";
-        debug_info = ss_debug.str();
-        if (original_Integral.GetValue() < 0) {
-            std::cout << debug_info << std::endl;
-            std::cout << "Integral after bkg subtraction is negative for histogram '"
-                << histogram.GetName() << /*"' in event category " << anaDataMetaId.eventCategory
-                << " for event region " << eventRegion << "." <<*/ std::endl;
-            return false;
-        }
-
-        std::ostringstream ss_negative;
-
-        for (Int_t n = 1; n <= histogram.GetNbinsX(); ++n) {
-            if (histogram.GetBinContent(n) >= 0) continue;
-            const std::string prefix = histogram.GetBinContent(n) + histogram.GetBinError(n) >= 0 ? "WARNING" : "ERROR";
-
-            ss_negative << prefix << ": " << histogram.GetName() << " Bin " << n << ", content = "
-                        << histogram.GetBinContent(n) << ", error = " << histogram.GetBinError(n)
-                        << ", bin limits=[" << histogram.GetBinLowEdge(n) << "," << histogram.GetBinLowEdge(n+1)
-                        << "].\n";
-            const double error = correction_factor - histogram.GetBinContent(n);
-            const double new_error = std::sqrt(std::pow(error,2) + std::pow(histogram.GetBinError(n),2));
-            histogram.SetBinContent(n, correction_factor);
-            histogram.SetBinError(n, new_error);
-        }
-        analysis::RenormalizeHistogram(histogram, original_Integral.GetValue(), true);
-        negative_bins_info = ss_negative.str();
-        return true;
-    }
-
-    void ProcessDataEvent(const EventAnalyzerDataId& anaDataId, EventInfo& event)
-    {
-        for(const auto& es : ana_setup.energy_scales) {
-            anaDataCollection.Fill(anaDataId.Set<EventEnergyScale>(es), event, 1);
         }
     }
 
     virtual void ProcessSpecialEvent(const SampleDescriptor& sample, const SampleDescriptor::Point& /*sample_wp*/,
-                                     const EventAnalyzerDataId& anaDataId, EventInfo& event, double weight)
+                                     const EventAnalyzerDataId& anaDataId, EventInfo& event, double weight,
+                                     bbtautau::AnaTupleWriter::DataIdMap& dataIds)
     {
         if(sample.sampleType == SampleType::DY) {
             static auto const find_b_index = [&]() {
@@ -473,7 +239,7 @@ protected:
                         (n_b_partons == sample.GetNWorkingPoints() - 1
                          && event->jets_nTotal_hadronFlavour_b > n_b_partons)) {
                     const auto finalId = anaDataId.Set(sample_wp.full_name);
-                    anaDataCollection.Fill(finalId, event, weight * sample_wp.norm_sf);
+                    dataIds[finalId] = std::make_tuple(weight * sample_wp.norm_sf, event.GetMvaScore());
                     wp_found = true;
                     break;
                 }
@@ -482,101 +248,21 @@ protected:
                 throw exception("Unable to find WP for DY event with lhe_n_b_partons = %1%") % event->lhe_n_b_partons;
 
         } else if(sample.sampleType == SampleType::TT) {
-            anaDataCollection.Fill(anaDataId, event, weight / event->weight_top_pt);
+            dataIds[anaDataId] = std::make_tuple(weight / event->weight_top_pt, event.GetMvaScore());
             if(anaDataId.Get<EventEnergyScale>() == EventEnergyScale::Central) {
 //                const double weight_topPt = event->weight_total * sample.cross_section * ana_setup.int_lumi
 //                        / event.GetSummaryInfo()->totalShapeWeight_withTopPt;
-                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtUp), event, weight); // FIXME
-                anaDataCollection.Fill(anaDataId.Set(EventEnergyScale::TopPtDown), event, weight); // FIXME
+                // FIXME
+                dataIds[anaDataId.Set(EventEnergyScale::TopPtUp)] = std::make_tuple(weight, event.GetMvaScore());
+                dataIds[anaDataId.Set(EventEnergyScale::TopPtDown)] = std::make_tuple(weight, event.GetMvaScore());
             }
         } else
             throw exception("Unsupported special event type '%1%'.") % sample.sampleType;
     }
 
-    void ProcessCombinedSamples(const std::vector<std::string>& sample_names)
-    {
-        std::cout << "Processing combined samples... " << std::endl;
-        for(const std::string& sample_name : sample_names) {
-            if(!cmb_sample_descriptors.count(sample_name))
-                throw exception("Combined sample '%1%' not found.") % sample_name;
-            CombinedSampleDescriptor& sample = cmb_sample_descriptors.at(sample_name);
-            if(sample.channels.size() && !sample.channels.count(ChannelId())) continue;
-            std::cout << sample.name << std::endl;
-            for(const std::string& sub_sample_name : sample.sample_descriptors) {
-                if(!sample_descriptors.count(sub_sample_name))
-                    throw exception("Unable to create '%1%': sub-sample '%2%' not found.")
-                        % sample_name % sub_sample_name;
-                SampleDescriptor& sub_sample =  sample_descriptors.at(sub_sample_name);
-                AddSampleToCombined(sample, sub_sample);
-            }
-        }
-    }
-
-    void AddSampleToCombined(CombinedSampleDescriptor& sample, SampleDescriptor& sub_sample)
-    {
-        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
-                EventSubCategoriesToProcess(), EventRegionsToProcess(), ana_setup.energy_scales)) {
-            const auto anaDataId = metaDataId.Set(sample.name);
-            auto& anaData = anaDataCollection.Get(anaDataId);
-            for(const auto& sub_sample_wp : sub_sample.working_points) {
-                const auto subDataId = metaDataId.Set(sub_sample_wp.full_name);
-                auto& subAnaData = anaDataCollection.Get(subDataId);
-                for(const auto& sub_entry : subAnaData.template GetEntriesEx<TH1D>()) {
-                    auto& entry = anaData.template GetEntryEx<TH1D>(sub_entry.first);
-                    for(const auto& hist : sub_entry.second->GetHistograms()) {
-                        entry(hist.first).Add(hist.second.get(), 1);
-                    }
-                }
-            }
-        }
-    }
-
-    template<typename SampleCollection>
-    static std::vector<std::string> FilterInactiveSamples(const SampleCollection& samples,
-                                                          const std::vector<std::string>& sample_names)
-    {
-        std::vector<std::string> filtered;
-        for(const auto& name : sample_names) {
-            if(!samples.count(name))
-                throw exception("Sample '%1%' not found.") % name;
-            const auto& sample = samples.at(name);
-            if(sample.channels.size() && !sample.channels.count(ChannelId())) continue;
-            filtered.push_back(name);
-        }
-        return filtered;
-    }
-
-    void RemoveUnusedSamples()
-    {
-        RemoveUnusedSamples(sample_descriptors, { &ana_setup.signals, &ana_setup.backgrounds, &ana_setup.data });
-        RemoveUnusedSamples(cmb_sample_descriptors, { &ana_setup.cmb_samples });
-    }
-
-    template<typename SampleCollection>
-    void RemoveUnusedSamples(SampleCollection& samples,
-                             const std::vector< std::vector<std::string>*> selected_sample_names) const
-    {
-        std::set<std::string> used_samples;
-        for(auto selected_collection : selected_sample_names) {
-            *selected_collection = FilterInactiveSamples(samples, *selected_collection);
-            used_samples.insert(selected_collection->begin(), selected_collection->end());
-        }
-
-        const std::set<std::string> all_sample_names = tools::collect_map_keys(samples);
-        for(const auto& sample_name : all_sample_names) {
-            if(!used_samples.count(sample_name))
-                samples.erase(sample_name);
-        }
-    }
-
 protected:
     AnalyzerArguments args;
-    AnaDataCollection anaDataCollection;
-    AnalyzerSetup ana_setup;
-    boost::optional<MvaReaderSetup> mva_setup;
-    SampleDescriptorCollection sample_descriptors;
-    CombinedSampleDescriptorCollection cmb_sample_descriptors;
-    EventSubCategorySet sub_categories_to_process;
+    bbtautau::AnaTupleWriter anaTupleWriter;
     mva_study::MvaReader mva_reader;
 };
 

--- a/Analysis/include/EventAnalyzerData.h
+++ b/Analysis/include/EventAnalyzerData.h
@@ -4,326 +4,65 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 #pragma once
 
 #include "AnalysisTools/Core/include/AnalyzerData.h"
-#include "h-tautau/Analysis/include/EventInfo.h"
-#include "AnalysisCategories.h"
+#include "AnaTuple.h"
 
 namespace analysis {
 
-class BaseEventAnalyzerData : public root_ext::AnalyzerData {
-public:    
-    using BinVector = std::vector<double>;
-    const bool SaveAll = true;
+class EventAnalyzerData : public root_ext::AnalyzerData {
+public:
+    using Entry = root_ext::AnalyzerDataEntry<TH1D>;
+    using EntryPtr = std::shared_ptr<Entry>;
+    using ValueType = float;
+    using EntrySource = std::pair<EntryPtr, const ValueType*>;
+    using HistContainer = std::map<std::string, EntrySource>;
+    using HistDesc = PropertyConfigReader::Item;
+    using HistDescCollection = PropertyConfigReader::ItemCollection;
 
-    const BinVector M_tt_Bins = { 10, 30, 50, 75, 90, 105, 120, 135, 150, 175, 210, 250, 300, 350, 400, 500 };
-    const BinVector M_ttbb_Bins = { 250, 260, 270, 280, 290, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550,
-                                    600, 650, 700, 850, 1000 };
-    const BinVector MT2_Bins = { 0, 25, 50, 75, 100, 125, 150, 175, 200, 250, 300, 500 };
-    const BinVector Pt_Bins = { 0, 20, 40, 60, 80, 100, 125, 150, 175, 200, 250, 300};
-
-    TH1D_ENTRY_CUSTOM_EX(m_ttbb, M_ttbb_Bins, "M_{#tau#tau+jj} (GeV)", "dN/dm_{#tau#tau+jj} (1/GeV)", false, 1.5, true, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(m_ttbb_kinfit, M_ttbb_Bins, "M_{H}^{kinfit} (GeV)", "dN/dm_{H}^{kinfit} (1/GeV)", false, 1.4, true, true)
-    TH1D_ENTRY_CUSTOM_EX(m_sv, M_tt_Bins, "M_{#tau#tau} (GeV)", "dN/dm_{#tau#tau} (1/GeV)", false, 1.6, true, true)
-    TH1D_ENTRY_CUSTOM_EX(MT2, MT2_Bins, "MT2_{H} (GeV)", "dN/dm (1/GeV)", false, 1.4, true, true)
-    TH1D_ENTRY_EX(mva_score, 40, -1, 1, "MVA score", "Events", true, 1.8, false, true)
-    TH1D_ENTRY_EX(mt_tot, 25, 0, 500, "M_{T}^{TOT}(GeV)", "Events", false, 1.5, false, SaveAll)
-    TH1D_ENTRY_EX(deta_hbbhtautau, 25, -5, 5, "#Delta#eta_{#tau#tau, jj}", "Events", false, 1.8, false, SaveAll)
-    TH1D_ENTRY_EX(dphi_hbbhtautau, 20, -4, 4, "#Delta#phi(#tau#tau, jj)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(MT_htautau, 20, 0, 250, "M_{T}^{#tau#tau}(GeV)", "Events", false, 1.4, false, SaveAll)
-
-    TH1D_ENTRY_CUSTOM_EX(m_tt_vis, M_tt_Bins, "M_{vis}(GeV)", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_H_tt, Pt_Bins, "P_{T}(GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_H_tt_MET, Pt_Bins, "P_{T}(GeV)", "Events", false, 1.5, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_1, Pt_Bins, "P_{T}(leading#tau_{h})(GeV)", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(eta_1, 20, -2.5, 2.5, "#eta(leading#tau_{h})", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(iso_1, 100, 0, 10, "Iso#tau_{1}", "Events", false, 1, false, SaveAll)
-    TH1D_ENTRY_EX(mt_1, 20, 0, 200, "M_{T}1(GeV)", "Events", false, 1.3, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_2, Pt_Bins, "P_{T}(subleading#tau_{h})(GeV)", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(eta_2, 20, -2.5, 2.5, "#eta(subleading#tau_{h})", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(iso_2, 100, 0, 10, "Iso#tau_{2}", "Events", false, 1, false, SaveAll)
-    TH1D_ENTRY_EX(mt_2, 20, 0, 200, "M_{T}2(GeV)", "Events", false, 1.3, false, SaveAll)
-    TH1D_ENTRY_EX(dR_l1l2, 20, 0, 4, "#DeltaR(#tau#tau)", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(abs_dphi_l1MET, 20, 0, 3.2, "|#Delta#phi(leading#tau_{h}, miss)|", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(dphi_htautauMET, 25, -4, 4, "#Delta#phi(#tau#tau, miss)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(dR_l1l2MET, 20, 0, 6, "#Delta R(leading#tau_{h}+subleading#tau_{h}, miss)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(dR_l1l2Pt_htautau, 20, 0, 500, "#DeltaR (leading#tau_{h},subleading#tau_{h}) P_{T}(#tau#tau) (GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(mass_l1l2MET, M_tt_Bins, "M_{leading#tau_{h}+subleading#tau_{h}+miss}", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_l1l2MET, Pt_Bins, "P_{T}(leading#tau_{h}+subleading#tau_{h}+miss) (GeV)", "Events", false, 1.4, false, SaveAll)
-
-    TH1D_ENTRY_EX(npv, 40, 0, 40,  "Number of Primary Vertex", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(MET, 25, 0, 200, "E_{T}^{miss}(GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(phiMET, 20, 0, 3.2, "#phi_{E_{T}^{miss}}", "Events", false, 1.5, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_MET, Pt_Bins, "P_{T}^{miss} (GeV)", "Events", false, 1.6, false, SaveAll)
-
-    TH1D_ENTRY_CUSTOM_EX(m_bb, M_tt_Bins, "M_{jj} (GeV)", "Events/ 20 GeV", false, 1.6, true, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_H_bb, Pt_Bins, "P_{T}(GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_b1, Pt_Bins, "Leading selected jet p_{T} (GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(eta_b1, 20, -2.5, 2.5, "Leading selected jet #eta", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(csv_b1, 20, 0.8, 1, "Leading selected jet CSV", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(pt_b2, Pt_Bins, "Subleading selected jet p_{T} (GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(eta_b2, 20, -2.5, 2.5, "Subleading selected jet #eta", "Events", false, 1.6, false, SaveAll)
-    TH1D_ENTRY_EX(csv_b2, 40, 0, 1, "Subleading selected jet CSV", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(costheta_METhbb, 20, -1, 1, "#cos #theta(jj, miss)", "Events", false, 1.4, false, SaveAll)
-
-    TH1D_ENTRY_EX(dR_b1b2, 25, 0, 5, "#DeltaR_{jj}", "Events", false, 1.5, false, SaveAll)
-    TH1D_ENTRY_EX(dR_b1b2_boosted, 25, 3, 8, "Boosted #Delta R_{jj} ", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(HT_otherjets, M_tt_Bins, "HT other jets (GeV)", "Events", false, 1.4, false, SaveAll)
-
-    TH1D_ENTRY_CUSTOM_EX(mass_top1, M_tt_Bins, "mass top_1 (GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_CUSTOM_EX(mass_top2, M_tt_Bins, "mass top_2 (GeV)", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(p_zeta, 30,-50, 250, "p_{#zeta}", "Events", false, 1.4, false, SaveAll)
-    TH1D_ENTRY_EX(p_zetavisible, 25, 0, 200, "p_{#zeta}^{vis}", "Events", false, 1.4, false, SaveAll)
-
-    BaseEventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
-        fill_all(_fill_all)
+    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName, Channel channel,
+                      const EventAnalyzerDataId& dataId, const bbtautau::AnaTuple* anaTuple,
+                      const std::set<std::string>& histogram_names, const HistDescCollection& descriptors) :
+        AnalyzerData(outputFile, directoryName, anaTuple == nullptr)
     {
-        Initialize(eventCategory);
-    }
-
-    BaseEventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
-                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
-        AnalyzerData(outputFile, directoryName, readMode), fill_all(_fill_all)
-    {
-        Initialize(eventCategory);
-    }
-
-    void FillBase(EventInfoBase& event, double weight)
-    {
-        if(event.HasBjetPair()) {
-            const double mX = event.GetResonanceMomentum(true, false).M();
-            m_ttbb().Fill(mX, weight);
-            const auto& kinfit = event.GetKinFitResults();
-            if(kinfit.HasValidMass())
-                m_ttbb_kinfit().Fill(kinfit.mass, weight);
-            MT2().Fill(event.GetMT2(), weight);
-            mva_score().Fill(event.GetMvaScore(), weight);
+        for(const auto& h_name : histogram_names) {
+            const auto& desc = FindDescriptor(h_name, channel, dataId, descriptors);
+            auto entry_ptr = std::make_shared<Entry>(h_name, this, desc);
+            const auto branch_ptr = anaTuple ? &anaTuple->get<ValueType>(h_name) : nullptr;
+            histograms[h_name] = EntrySource(entry_ptr, branch_ptr);
         }
+    }
 
-        const double m_SVfit = event.GetHiggsTTMomentum(true).M();
-        m_sv().Fill(m_SVfit, weight);
-
-        if(!fill_all) return;
-
-        const auto& Htt = event.GetHiggsTTMomentum(false);
-        const auto& t1 = event.GetLeg(1);
-        const auto& t2 = event.GetLeg(2);
-
-        m_tt_vis().Fill(Htt.M(), weight);
-        pt_H_tt().Fill(Htt.Pt(), weight);
-        pt_H_tt_MET().Fill((Htt + event.GetMET().GetMomentum()).Pt(), weight);
-        pt_1().Fill(t1.GetMomentum().pt(), weight);
-        eta_1().Fill(t1.GetMomentum().eta(), weight);
-        iso_1().Fill(t1.GetIsolation(), weight);
-        mt_1().Fill(Calculate_MT(t1.GetMomentum(), event.GetMET().GetMomentum()), weight);
-        pt_2().Fill(t2.GetMomentum().pt(), weight);
-        eta_2().Fill(t2.GetMomentum().eta(), weight);
-        iso_2().Fill(t2.GetIsolation(), weight);
-        mt_2().Fill(Calculate_MT(t2.GetMomentum(), event.GetMET().GetMomentum()), weight);
-
-        dR_l1l2().Fill(ROOT::Math::VectorUtil::DeltaR(t1.GetMomentum(),t2.GetMomentum()), weight);
-        abs_dphi_l1MET().Fill(std::abs(ROOT::Math::VectorUtil::DeltaPhi(t1.GetMomentum(), event.GetMET().GetMomentum())), weight);
-        dphi_htautauMET().Fill(ROOT::Math::VectorUtil::DeltaPhi(event.GetHiggsTTMomentum(true), event.GetMET().GetMomentum()),weight);
-        dR_l1l2MET().Fill(ROOT::Math::VectorUtil::DeltaR(event.GetHiggsTTMomentum(false), event.GetMET().GetMomentum()),weight);
-        dR_l1l2Pt_htautau().Fill(ROOT::Math::VectorUtil::DeltaR(t1.GetMomentum(),t2.GetMomentum())*event.GetHiggsTTMomentum(true).pt(), weight);
-        mass_l1l2MET().Fill((event.GetHiggsTTMomentum(false)+event.GetMET().GetMomentum()).M(), weight);
-        pt_l1l2MET().Fill((event.GetHiggsTTMomentum(false)+event.GetMET().GetMomentum()).pt(), weight);
-        MT_htautau().Fill(Calculate_MT(event.GetHiggsTTMomentum(true), event.GetMET().GetMomentum()), weight);
-
-        npv().Fill(event->npv,weight);
-        MET().Fill(event.GetMET().GetMomentum().Pt(), weight);
-        phiMET().Fill(event.GetMET().GetMomentum().Phi(),weight);
-
-        pt_MET().Fill(event.GetMET().GetMomentum().pt(), weight);
-
-        if(!event.HasBjetPair()) return;
-
-        const auto& Hbb = event.GetHiggsBB();
-        const auto& b1 = Hbb.GetFirstDaughter();
-        const auto& b2 = Hbb.GetSecondDaughter();
-        m_bb().Fill(Hbb.GetMomentum().M(), weight);
-        pt_H_bb().Fill(Hbb.GetMomentum().Pt(), weight);
-        pt_b1().Fill(b1.GetMomentum().pt(), weight);
-        eta_b1().Fill(b1.GetMomentum().Eta(), weight);
-        csv_b1().Fill(b1->csv(), weight);
-        pt_b2().Fill(b2.GetMomentum().Pt(), weight);
-        eta_b2().Fill(b2.GetMomentum().Eta(), weight);
-        csv_b2().Fill(b2->csv(), weight);
-
-        dphi_hbbhtautau().Fill(ROOT::Math::VectorUtil::DeltaPhi(Hbb.GetMomentum(), event.GetHiggsTTMomentum(true)), weight);
-        deta_hbbhtautau().Fill((Hbb.GetMomentum()-event.GetHiggsTTMomentum(true)).Eta(), weight);
-        mt_tot().Fill(Calculate_TotalMT(t1.GetMomentum(),t2.GetMomentum(),event.GetMET().GetMomentum()), weight);
-
-        costheta_METhbb().Fill(four_bodies::Calculate_cosTheta_2bodies(event.GetMET().GetMomentum(), Hbb.GetMomentum()), weight);
-        dR_b1b2().Fill(ROOT::Math::VectorUtil::DeltaR(b1.GetMomentum(), b2.GetMomentum()), weight);
-        dR_b1b2_boosted().Fill(four_bodies::Calculate_dR_boosted(b1.GetMomentum(), b2.GetMomentum(), Hbb.GetMomentum()), weight);
-        HT_otherjets().Fill(event->ht_other_jets, weight);
-
-        mass_top1().Fill(four_bodies::Calculate_topPairMasses(t1.GetMomentum(), t2.GetMomentum(), b1.GetMomentum(), b2.GetMomentum(), event.GetMET().GetMomentum()).first, weight);
-        mass_top2().Fill(four_bodies::Calculate_topPairMasses(t1.GetMomentum(), t2.GetMomentum(), b1.GetMomentum(), b2.GetMomentum(), event.GetMET().GetMomentum()).second, weight);
-
-        p_zeta().Fill(Calculate_Pzeta(t1.GetMomentum(), t2.GetMomentum(),  event.GetMET().GetMomentum()), weight);
-        p_zetavisible().Fill(Calculate_visiblePzeta(t1.GetMomentum(), t2.GetMomentum()), weight);
-
+    void Fill(double weight)
+    {
+        if(ReadMode())
+            throw exception("Fill is not available in read mode.");
+        for(auto& entry : histograms)
+            (*entry.second.first)().Fill(*entry.second.second, weight);
     }
 
 private:
-    void Initialize(const EventCategory& eventCategory)
+    static const HistDesc& FindDescriptor(const std::string& h_name, Channel channel, const EventAnalyzerDataId& dataId,
+                                          const HistDescCollection& descriptors)
     {
-        static const BinVector boosted_MT2_bins = { 0, 150, 200, 250, 300, 500 };
-
-        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
-            MT2.SetMasterHist(boosted_MT2_bins, "MT2_{H} (GeV)", "dN/dm (1/GeV)", false, 1.4, true, true);
+        const std::vector<std::string> desc_name_candidates = {
+            boost::str(boost::format("%1%/%2%/%3%/%4%") % h_name % channel % dataId.Get<EventCategory>()
+                                                        % dataId.Get<EventSubCategory>()),
+            boost::str(boost::format("%1%/%2%/*/%3%") % h_name % channel % dataId.Get<EventSubCategory>()),
+            boost::str(boost::format("%1%/*/*/%2%") % h_name % dataId.Get<EventSubCategory>()),
+            boost::str(boost::format("%1%/%2%/%3%") % h_name % channel % dataId.Get<EventCategory>()),
+            boost::str(boost::format("%1%/*/%2%") % h_name % dataId.Get<EventCategory>()),
+            boost::str(boost::format("%1%/%2%") % h_name % channel),
+            h_name
+        };
+        for(const auto& desc_name : desc_name_candidates) {
+            auto iter = descriptors.find(desc_name);
+            if(iter != descriptors.end())
+                return iter->second;
         }
-    }
-
-protected:
-    bool fill_all;
-};
-
-template<typename _FirstLeg, typename _SecondLeg>
-class EventAnalyzerData : public BaseEventAnalyzerData {
-public:
-    using FirstLeg = _FirstLeg;
-    using SecondLeg = _SecondLeg;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-
-    using BaseEventAnalyzerData::BaseEventAnalyzerData;
-
-    void Fill(EventInfo& event, double weight)
-    {
-        FillBase(event, weight);
-    }
-};
-
-template<>
-class EventAnalyzerData<ElectronCandidate, TauCandidate> : public BaseEventAnalyzerData {
-public:
-    using FirstLeg = ElectronCandidate;
-    using SecondLeg = TauCandidate;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-
-    EventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
-        BaseEventAnalyzerData(eventCategory, _fill_all)
-    {
-        Initialize(eventCategory);
-    }
-
-    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
-                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
-        BaseEventAnalyzerData(outputFile, directoryName, eventCategory, _fill_all, readMode)
-    {
-        Initialize(eventCategory);
-    }
-
-    void Fill(EventInfo& event, double weight)
-    {
-        FillBase(event, weight);
+        throw exception("Descriptor for histogram '%1%' not found.") % h_name;
     }
 
 private:
-    void Initialize(const EventCategory& eventCategory)
-    {
-        static const std::vector<double> res_mva_bins = { -1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
-                                                          0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 };
-        static const std::vector<double> boosted_mva_bins = { -1, 0.6, 0.8, 1 };
-
-        auto mva_bins = &res_mva_bins;
-        auto mva_draw_sf = 1.2;
-        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
-            mva_bins = &boosted_mva_bins;
-            mva_draw_sf = 2;
-        }
-
-        mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
-    }
-};
-
-template<>
-class EventAnalyzerData<MuonCandidate, TauCandidate> : public BaseEventAnalyzerData {
-public:
-    using FirstLeg = MuonCandidate;
-    using SecondLeg = TauCandidate;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-
-    EventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
-        BaseEventAnalyzerData(eventCategory, _fill_all)
-    {
-        Initialize(eventCategory);
-    }
-
-    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
-                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
-        BaseEventAnalyzerData(outputFile, directoryName, eventCategory, _fill_all, readMode)
-    {
-        Initialize(eventCategory);
-    }
-
-    void Fill(EventInfo& event, double weight)
-    {
-        FillBase(event, weight);
-    }
-
-private:
-    void Initialize(const EventCategory& eventCategory)
-    {
-        static const std::vector<double> res_mva_bins = { -1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
-                                                          0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 1 };
-        static const std::vector<double> boosted_mva_bins = { -1, 0.6, 0.8, 0.9, 1 };
-
-        auto mva_bins = &res_mva_bins;
-        auto mva_draw_sf = 1.2;
-        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
-            mva_bins = &boosted_mva_bins;
-            mva_draw_sf = 2;
-        }
-
-        mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
-    }
-};
-
-template<>
-class EventAnalyzerData<TauCandidate, TauCandidate> : public BaseEventAnalyzerData {
-public:
-    using FirstLeg = TauCandidate;
-    using SecondLeg = TauCandidate;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-
-    EventAnalyzerData(const EventCategory& eventCategory, bool _fill_all) :
-        BaseEventAnalyzerData(eventCategory, _fill_all)
-    {
-        Initialize(eventCategory);
-    }
-
-    EventAnalyzerData(std::shared_ptr<TFile> outputFile, const std::string& directoryName,
-                          const EventCategory& eventCategory, bool _fill_all, bool readMode) :
-        BaseEventAnalyzerData(outputFile, directoryName, eventCategory, _fill_all, readMode)
-    {
-        Initialize(eventCategory);
-    }
-
-    void Fill(EventInfo& event, double weight)
-    {
-        FillBase(event, weight);
-    }
-
-private:
-    void Initialize(const EventCategory& eventCategory)
-    {
-        static const BinVector res1b_mva_bins = { -1, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0,
-                                                            0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 };
-        static const BinVector res2b_mva_bins = { -1, -0.8, -0.6, -0.3, 0.1, 0.4, 0.7, 0.85, 1 };
-        static const BinVector boosted_mva_bins = { -1, 0, 0.6, 0.8, 1 };
-
-        auto mva_bins = &res1b_mva_bins;
-        auto mva_draw_sf = 1.4;
-        if(eventCategory.HasBoostConstraint() && eventCategory.IsBoosted()) {
-            mva_bins = &boosted_mva_bins;
-            mva_draw_sf = 2;
-        } else if(eventCategory.HasBtagConstraint() && eventCategory.N_btag() > 1) {
-            mva_bins = &res2b_mva_bins;
-        }
-
-        mva_score.SetMasterHist(*mva_bins, "MVA score", "dN / bin width", false, mva_draw_sf, true, true);
-    }
+    HistContainer histograms;
 };
 
 } // namespace analysis

--- a/Analysis/include/EventAnalyzerDataCollection.h
+++ b/Analysis/include/EventAnalyzerDataCollection.h
@@ -8,212 +8,20 @@ This file is part of https://github.com/hh-italian-group/h-tautau. */
 
 namespace analysis {
 
-namespace detail {
-
-template<typename CollectionItem>
-struct EventAnalyzerDataId_IdElementAccessor {
-    using ElementType = CollectionItem;
-    static ElementType Get(const CollectionItem& item) { return item; }
-};
-
-template<typename Key, typename Value>
-struct EventAnalyzerDataId_IdElementAccessor<std::pair<const Key, Value>> {
-    using ElementType = Key;
-    static ElementType Get(const std::pair<Key, Value>& item) { return item.first; }
-};
-
-} // namesapce detail
-
-struct EventAnalyzerDataId {
+class EventAnalyzerDataCollection {
 public:
-    template<typename T> using Optional = boost::optional<T>;
-    using Tuple = std::tuple<Optional<EventCategory>, Optional<EventSubCategory>, Optional<EventRegion>,
-                             Optional<EventEnergyScale>, Optional<Dataset>>;
-    static constexpr size_t TupleSize = std::tuple_size<Tuple>::value;
-
-    EventAnalyzerDataId() {}
-    template<typename ...Args>
-    EventAnalyzerDataId(Args&&... args) { Initialize(std::forward<Args>(args)...); }
-
-    template<typename T>
-    bool Has() const { return std::get<Optional<T>>(id_tuple).is_initialized(); }
-    template<typename T>
-    EventAnalyzerDataId Set(const T& value) const
-    {
-        EventAnalyzerDataId new_id(*this);
-        std::get<Optional<T>>(new_id.id_tuple) = value;
-        return new_id;
-    }
-    template<typename T>
-    const T& Get() const
-    {
-        if(!std::get<Optional<T>>(id_tuple).is_initialized())
-            throw exception("%1% is not specified in EventAnalyzerDataId = '%2%'.") % typeid(T).name() % *this;
-        return *std::get<Optional<T>>(id_tuple);
-    }
-
-    bool operator< (const EventAnalyzerDataId& other) const { return id_tuple < other.id_tuple; }
-    std::string GetName() const { return GetSubName(std::make_index_sequence<TupleSize>{}); }
-    bool IsComplete() const { return ItemsAreInitialized(std::make_index_sequence<TupleSize>{}); }
-
-    template<typename ...Collections>
-    static std::vector<EventAnalyzerDataId> MetaLoop(Collections&&... cols)
-    {
-        std::vector<EventAnalyzerDataId> result;
-        AddMetaLoopLevels(result, std::forward<Collections>(cols)...);
-        return result;
-    }
-
-    static EventAnalyzerDataId Parse(const std::string& str)
-    {
-        static const std::string separator = "/";
-        try {
-            std::vector<std::string> item_strings = SplitValueList(str, true, separator, false);
-            if(item_strings.size() != std::tuple_size<Tuple>::value)
-                throw exception("Number of elements != %1%.") % std::tuple_size<Tuple>::value;
-            EventAnalyzerDataId id;
-            id.ParseAllItems(item_strings, std::make_index_sequence<TupleSize>{});
-            return id;
-        } catch(std::exception& e) {
-            throw exception("Invalid EventAnalyzerDataId = '%1%'. %2%") % str % e.what();
-        }
-    }
-
-private:
-    void Initialize() {}
-
-    template<typename T, typename ...Args>
-    void Initialize(T&& value, Args&&... other_values)
-    {
-        using ValueType = typename std::remove_const<typename std::remove_reference<T>::type>::type;
-        std::get<Optional<ValueType>>(id_tuple) = value;
-        Initialize(std::forward<Args>(other_values)...);
-    }
-
-    template<size_t n>
-    std::string ItemToString() const
-    {
-        static const std::string wildcard = "*";
-        const auto& value = std::get<n>(id_tuple);
-        return value.is_initialized() ? ToString(*value) : wildcard;
-    }
-
-    template<size_t ...n>
-    std::string GetSubName(std::index_sequence<n...>) const
-    {
-        static const std::string separator = "/";
-        const std::vector<std::string> item_names = { ItemToString<n>()... };
-        std::string sub_name;
-        for(const auto& name : item_names)
-            sub_name += name + separator;
-        if(sub_name.size())
-            sub_name.erase(sub_name.size() - 1);
-        return sub_name;
-    }
-
-    template<size_t n>
-    bool ParseItem(const std::vector<std::string>& item_strings)
-    {
-        using TupleElement = typename std::tuple_element<n, Tuple>::type;
-        using ValueType = typename TupleElement::value_type;
-        static const std::string wildcard = "*";
-        const std::string& str = item_strings.at(n);
-        if(str != wildcard)
-            std::get<n>(id_tuple) = ::analysis::Parse<ValueType>(str);
-        return true;
-    }
-
-    template<size_t ...n>
-    void ParseAllItems(const std::vector<std::string>& item_strings, std::index_sequence<n...>)
-    {
-        const std::vector<bool> res = { ParseItem<n>(item_strings)... };
-    }
-
-    template<size_t ...n>
-    bool ItemsAreInitialized(std::index_sequence<n...>) const
-    {
-        const std::vector<bool> is_initialized = { std::get<n>(id_tuple).is_initialized()... };
-        for(bool init : is_initialized)
-            if(!init) return false;
-        return true;
-    }
-
-    static void AddMetaLoopLevels(std::vector<EventAnalyzerDataId>&) {}
-
-    template<typename Collection, typename ...OtherCollections>
-    static void AddMetaLoopLevels(std::vector<EventAnalyzerDataId>& result, Collection&& collection,
-                         OtherCollections&&... other_collections)
-    {
-        using Item = typename std::remove_reference<Collection>::type::value_type;
-        using ElementAccessor = typename detail::EventAnalyzerDataId_IdElementAccessor<Item>;
-        using ElementType = typename ElementAccessor::ElementType;
-
-        const size_t N = std::max<size_t>(result.size(), 1) * collection.size();
-        std::vector<EventAnalyzerDataId> new_result;
-        new_result.reserve(N);
-        if(!result.size()) {
-            for(const auto& item : collection) {
-                const auto& id_element = ElementAccessor::Get(item);
-                new_result.emplace_back(id_element);
-            }
-        } else {
-            for(const EventAnalyzerDataId& ref_id : result) {
-                if(ref_id.Has<ElementType>())
-                    throw exception("Duplicated element type '%1%' in meta loop.") % typeid(ElementType).name();
-                for(const auto& item : collection) {
-                    const auto& id_element = ElementAccessor::Get(item);
-                    new_result.push_back(ref_id.Set(id_element));
-                }
-            }
-        }
-
-        result = std::move(new_result);
-        AddMetaLoopLevels(result, std::forward<OtherCollections>(other_collections)...);
-    }
-
-private:
-    Tuple id_tuple;
-};
-
-std::ostream& operator<<(std::ostream& s, const EventAnalyzerDataId& id)
-{
-    s << id.GetName();
-    return s;
-}
-
-std::istream& operator>>(std::istream& s, EventAnalyzerDataId& id)
-{
-    std::string str;
-    s >> str;
-    id = EventAnalyzerDataId::Parse(str);
-    return s;
-}
-
-class BaseEventAnalyzerDataCollection {
-public:
-    virtual ~BaseEventAnalyzerDataCollection() {}
-    virtual BaseEventAnalyzerData& GetBase(const EventAnalyzerDataId& id) = 0;
-
-};
-
-template<typename AnaData>
-class EventAnalyzerDataCollection : public BaseEventAnalyzerDataCollection {
-public:
-    using Data = AnaData;
+    using Data = EventAnalyzerData;
     using DataPtr = std::shared_ptr<Data>;
     using DataId = EventAnalyzerDataId;
     using DataMap = std::map<DataId, DataPtr>;
+    using Tuple = bbtautau::AnaTuple;
+    using NameSet = std::set<std::string>;
+    using DescSet = PropertyConfigReader::ItemCollection;
 
-    explicit EventAnalyzerDataCollection(const std::string& inputFileName) :
-        file(root_ext::OpenRootFile(inputFileName)), readMode(true)
+    explicit EventAnalyzerDataCollection(std::shared_ptr<TFile> _file, Channel _channel, const Tuple* _tuple,
+                                         const NameSet& _histNames, const DescSet& _histDescs) :
+        file(_file), channel(_channel), tuple(_tuple), histNames(_histNames), histDescs(_histDescs)
     {}
-
-    EventAnalyzerDataCollection(const std::string& outputFileName, bool store) :
-        readMode(false)
-    {
-        if(store)
-            file = root_ext::CreateRootFile(outputFileName);
-    }
 
     Data& Get(const DataId& id)
     {
@@ -223,31 +31,30 @@ public:
         return *anaData;
     }
 
-    virtual BaseEventAnalyzerData& GetBase(const DataId& id) override { return Get(id); }
     const DataMap& GetAll() const { return anaDataMap; }
+    Channel ChannelId() const { return channel; }
+    bool ReadMode() const { return tuple != nullptr; }
 
-    template<typename EventInfo>
-    void Fill(const DataId& id, EventInfo& event, double weight)
+    void Fill(const DataId& id, double weight)
     {
-        Get(id).Fill(event, weight);
+        Get(id).Fill(weight);
     }
 
 private:
     DataPtr Make(const DataId& id) const
     {
-        const bool fill_all = id.Get<EventEnergyScale>() == EventEnergyScale::Central;
-        if(file) {
-            if(!id.IsComplete())
-                throw exception("EventAnalyzerDataId '%1%' is not complete.") % id;
-            const std::string dir_name = id.GetName();
-            return std::make_shared<Data>(file, dir_name, id.Get<EventCategory>(), fill_all, readMode);
-        }
-        return std::make_shared<Data>(id.Get<EventCategory>(), fill_all);
+        if(!id.IsComplete())
+            throw exception("EventAnalyzerDataId '%1%' is not complete.") % id;
+        const std::string dir_name = id.GetName();
+        return std::make_shared<Data>(file, dir_name, channel, id, tuple, histNames, histDescs);
     }
 
 private:
     std::shared_ptr<TFile> file;
-    bool readMode;
+    Channel channel;
+    const Tuple* tuple;
+    NameSet histNames;
+    DescSet histDescs;
     DataMap anaDataMap;
 };
 

--- a/Analysis/include/EventAnalyzerDataId.h
+++ b/Analysis/include/EventAnalyzerDataId.h
@@ -1,0 +1,191 @@
+/*! Definition of identifier of event analyzer data container.
+This file is part of https://github.com/hh-italian-group/h-tautau. */
+
+#pragma once
+
+#include "AnalysisCategories.h"
+
+namespace analysis {
+
+namespace detail {
+
+template<typename CollectionItem>
+struct EventAnalyzerDataId_IdElementAccessor {
+    using ElementType = CollectionItem;
+    static ElementType Get(const CollectionItem& item) { return item; }
+};
+
+template<typename Key, typename Value>
+struct EventAnalyzerDataId_IdElementAccessor<std::pair<const Key, Value>> {
+    using ElementType = Key;
+    static ElementType Get(const std::pair<Key, Value>& item) { return item.first; }
+};
+
+} // namesapce detail
+
+struct EventAnalyzerDataId {
+public:
+    template<typename T> using Optional = boost::optional<T>;
+    using Tuple = std::tuple<Optional<EventCategory>, Optional<EventSubCategory>, Optional<EventRegion>,
+                             Optional<EventEnergyScale>, Optional<Dataset>>;
+    static constexpr size_t TupleSize = std::tuple_size<Tuple>::value;
+
+    EventAnalyzerDataId() {}
+    template<typename ...Args>
+    EventAnalyzerDataId(Args&&... args) { Initialize(std::forward<Args>(args)...); }
+
+    template<typename T>
+    bool Has() const { return std::get<Optional<T>>(id_tuple).is_initialized(); }
+    template<typename T>
+    EventAnalyzerDataId Set(const T& value) const
+    {
+        EventAnalyzerDataId new_id(*this);
+        std::get<Optional<T>>(new_id.id_tuple) = value;
+        return new_id;
+    }
+    template<typename T>
+    const T& Get() const
+    {
+        if(!std::get<Optional<T>>(id_tuple).is_initialized())
+            throw exception("%1% is not specified in EventAnalyzerDataId = '%2%'.") % typeid(T).name() % *this;
+        return *std::get<Optional<T>>(id_tuple);
+    }
+
+    bool operator< (const EventAnalyzerDataId& other) const { return id_tuple < other.id_tuple; }
+    std::string GetName() const { return GetSubName(std::make_index_sequence<TupleSize>{}); }
+    bool IsComplete() const { return ItemsAreInitialized(std::make_index_sequence<TupleSize>{}); }
+
+    template<typename ...Collections>
+    static std::vector<EventAnalyzerDataId> MetaLoop(Collections&&... cols)
+    {
+        std::vector<EventAnalyzerDataId> result;
+        AddMetaLoopLevels(result, std::forward<Collections>(cols)...);
+        return result;
+    }
+
+    static EventAnalyzerDataId Parse(const std::string& str)
+    {
+        static const std::string separator = "/";
+        try {
+            std::vector<std::string> item_strings = SplitValueList(str, true, separator, false);
+            if(item_strings.size() != std::tuple_size<Tuple>::value)
+                throw exception("Number of elements != %1%.") % std::tuple_size<Tuple>::value;
+            EventAnalyzerDataId id;
+            id.ParseAllItems(item_strings, std::make_index_sequence<TupleSize>{});
+            return id;
+        } catch(std::exception& e) {
+            throw exception("Invalid EventAnalyzerDataId = '%1%'. %2%") % str % e.what();
+        }
+    }
+
+private:
+    void Initialize() {}
+
+    template<typename T, typename ...Args>
+    void Initialize(T&& value, Args&&... other_values)
+    {
+        using ValueType = typename std::remove_const<typename std::remove_reference<T>::type>::type;
+        std::get<Optional<ValueType>>(id_tuple) = value;
+        Initialize(std::forward<Args>(other_values)...);
+    }
+
+    template<size_t n>
+    std::string ItemToString() const
+    {
+        static const std::string wildcard = "*";
+        const auto& value = std::get<n>(id_tuple);
+        return value.is_initialized() ? ToString(*value) : wildcard;
+    }
+
+    template<size_t ...n>
+    std::string GetSubName(std::index_sequence<n...>) const
+    {
+        static const std::string separator = "/";
+        const std::vector<std::string> item_names = { ItemToString<n>()... };
+        std::string sub_name;
+        for(const auto& name : item_names)
+            sub_name += name + separator;
+        if(sub_name.size())
+            sub_name.erase(sub_name.size() - 1);
+        return sub_name;
+    }
+
+    template<size_t n>
+    bool ParseItem(const std::vector<std::string>& item_strings)
+    {
+        using TupleElement = typename std::tuple_element<n, Tuple>::type;
+        using ValueType = typename TupleElement::value_type;
+        static const std::string wildcard = "*";
+        const std::string& str = item_strings.at(n);
+        if(str != wildcard)
+            std::get<n>(id_tuple) = ::analysis::Parse<ValueType>(str);
+        return true;
+    }
+
+    template<size_t ...n>
+    void ParseAllItems(const std::vector<std::string>& item_strings, std::index_sequence<n...>)
+    {
+        const std::vector<bool> res = { ParseItem<n>(item_strings)... };
+    }
+
+    template<size_t ...n>
+    bool ItemsAreInitialized(std::index_sequence<n...>) const
+    {
+        const std::vector<bool> is_initialized = { std::get<n>(id_tuple).is_initialized()... };
+        for(bool init : is_initialized)
+            if(!init) return false;
+        return true;
+    }
+
+    static void AddMetaLoopLevels(std::vector<EventAnalyzerDataId>&) {}
+
+    template<typename Collection, typename ...OtherCollections>
+    static void AddMetaLoopLevels(std::vector<EventAnalyzerDataId>& result, Collection&& collection,
+                         OtherCollections&&... other_collections)
+    {
+        using Item = typename std::remove_reference<Collection>::type::value_type;
+        using ElementAccessor = typename detail::EventAnalyzerDataId_IdElementAccessor<Item>;
+        using ElementType = typename ElementAccessor::ElementType;
+
+        const size_t N = std::max<size_t>(result.size(), 1) * collection.size();
+        std::vector<EventAnalyzerDataId> new_result;
+        new_result.reserve(N);
+        if(!result.size()) {
+            for(const auto& item : collection) {
+                const auto& id_element = ElementAccessor::Get(item);
+                new_result.emplace_back(id_element);
+            }
+        } else {
+            for(const EventAnalyzerDataId& ref_id : result) {
+                if(ref_id.Has<ElementType>())
+                    throw exception("Duplicated element type '%1%' in meta loop.") % typeid(ElementType).name();
+                for(const auto& item : collection) {
+                    const auto& id_element = ElementAccessor::Get(item);
+                    new_result.push_back(ref_id.Set(id_element));
+                }
+            }
+        }
+
+        result = std::move(new_result);
+        AddMetaLoopLevels(result, std::forward<OtherCollections>(other_collections)...);
+    }
+
+private:
+    Tuple id_tuple;
+};
+
+inline std::ostream& operator<<(std::ostream& s, const EventAnalyzerDataId& id)
+{
+    s << id.GetName();
+    return s;
+}
+
+inline std::istream& operator>>(std::istream& s, EventAnalyzerDataId& id)
+{
+    std::string str;
+    s >> str;
+    id = EventAnalyzerDataId::Parse(str);
+    return s;
+}
+
+} // namespace analysis

--- a/Analysis/include/LimitsInputProducer.h
+++ b/Analysis/include/LimitsInputProducer.h
@@ -8,21 +8,15 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 
 namespace analysis {
 
-template<typename _FirstLeg, typename _SecondLeg>
 class LimitsInputProducer {
 public:
-    using FirstLeg = _FirstLeg;
-    using SecondLeg = _SecondLeg;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-    using AnaData = ::analysis::EventAnalyzerData<FirstLeg, SecondLeg>;
-    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection<AnaData>;
+    using AnaData = ::analysis::EventAnalyzerData;
+    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection;
     using Sample = ::analysis::SampleDescriptorBase;
     using SampleWP = Sample::Point;
     using SampleWPCollection = std::map<std::string, SampleWP>;
     using Hist = TH1D;
     using HistPtr = std::shared_ptr<root_ext::SmartHistogram<Hist>>;
-
-    static constexpr Channel ChannelId() { return ChannelInfo::IdentifyChannel<FirstLeg, SecondLeg>(); }
 
     static std::string FullDataCardName(const std::string& datacard_name, EventEnergyScale es)
     {
@@ -60,7 +54,7 @@ public:
     {
         static constexpr double tiny_value = 1e-9;
         static constexpr double tiny_value_error = tiny_value;
-        static const std::string dirNamePrefix = ToString(ChannelId()) + "_";
+        static const std::string dirNamePrefix = ToString(anaDataCollection->ChannelId()) + "_";
 
         std::ostringstream s_file_name;
         s_file_name << outputFileNamePrefix << "_" << hist_name;
@@ -80,7 +74,7 @@ public:
             const SampleWP& sampleWP = sampleWorkingPoints.at(metaId.Get<std::string>());
             const auto anaDataId = metaId.Set(eventSubCategory).Set(metaId.Get<EventRegion>());
             const auto& anaData = anaDataCollection->Get(anaDataId);
-            auto& hist_entry = anaData.template GetEntryEx<TH1D>(hist_name);
+            auto& hist_entry = anaData.GetEntryEx<TH1D>(hist_name);
             std::shared_ptr<TH1D> hist;
             if(hist_entry.GetHistograms().count(""))
                 hist = std::make_shared<TH1D>(hist_entry());

--- a/Analysis/include/SampleDescriptor.h
+++ b/Analysis/include/SampleDescriptor.h
@@ -27,7 +27,7 @@ struct AnalyzerSetup {
     std::vector<std::string> data, signals, backgrounds, cmb_samples;
     std::vector<std::string> draw_sequence;
     std::map<EventCategory, std::string> limit_categories;
-    std::string mva_setup;
+    std::string mva_setup, hist_cfg;
 
     bool IsSignal(const std::string& sample_name) const
     {

--- a/Analysis/include/SampleDescriptorConfigEntryReader.h
+++ b/Analysis/include/SampleDescriptorConfigEntryReader.h
@@ -28,6 +28,7 @@ public:
         CheckReadParamCounts("draw_sequence", 1, Condition::less_equal);
         CheckReadParamCounts("limit_category", 0, Condition::greater_equal);
         CheckReadParamCounts("mva_setup", 1, Condition::less_equal);
+        CheckReadParamCounts("hist_cfg", 1, Condition::less_equal);
 
         ConfigEntryReaderT<AnalyzerSetup>::EndEntry();
     }
@@ -48,6 +49,7 @@ public:
         ParseEntryList("draw_sequence", current.draw_sequence);
         ParseEntry("limit_category", current.limit_categories);
         ParseEntry("mva_setup", current.mva_setup);
+        ParseEntry("hist_cfg", current.hist_cfg);
     }
 };
 

--- a/Analysis/include/StackedPlotsProducer.h
+++ b/Analysis/include/StackedPlotsProducer.h
@@ -9,27 +9,20 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 
 namespace analysis {
 
-template<typename _FirstLeg, typename _SecondLeg>
 class StackedPlotsProducer {
 public:
-    using FirstLeg = _FirstLeg;
-    using SecondLeg = _SecondLeg;
-    using EventInfo = ::analysis::EventInfo<FirstLeg, SecondLeg>;
-    using AnaData = ::analysis::EventAnalyzerData<FirstLeg, SecondLeg>;
-    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection<AnaData>;
+    using AnaData = ::analysis::EventAnalyzerData;
+    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection;
     using Sample = ::analysis::SampleDescriptorBase;
     using SampleCollection = std::vector<const Sample*>;
     using Hist = TH1D;
     using HistPtr = std::shared_ptr<root_ext::SmartHistogram<Hist>>;
 
-    static constexpr Channel ChannelId() { return ChannelInfo::IdentifyChannel<FirstLeg, SecondLeg>(); }
-    static const std::string& ChannelNameLatex() { return __Channel_names_latex.EnumToString(ChannelId()); }
-
     static SampleCollection CreateOrderedSampleCollection(const std::vector<std::string>& draw_sequence,
                                                           const SampleDescriptorCollection& samples,
                                                           const CombinedSampleDescriptorCollection& combined_samples,
                                                           const std::vector<std::string>& signals,
-                                                          const std::vector<std::string>& data)
+                                                          const std::vector<std::string>& data, Channel channel)
     {
         SampleCollection selected_samples;
         for(const auto& name : draw_sequence) {
@@ -54,11 +47,12 @@ public:
         }
         SampleCollection result;
         for(const Sample* sample : selected_samples) {
-            if(!sample->channels.size() || sample->channels.count(ChannelId()))
+            if(!sample->channels.size() || sample->channels.count(channel))
                 result.push_back(sample);
         }
         return result;
     }
+
 
     StackedPlotsProducer(AnaDataCollection& _anaDataCollection, const SampleCollection& _samples,
                          bool _isBlind, bool _drawRatio, const std::set<std::string>& _histogramNames = {}) :
@@ -73,6 +67,9 @@ public:
             }
         }
     }
+
+    Channel ChannelId() const { return anaDataCollection->ChannelId(); }
+    const std::string& ChannelNameLatex() const { return __Channel_names_latex.EnumToString(ChannelId()); }
 
     void PrintStackedPlots(const std::string& outputFileNamePrefix, const EventRegion& eventRegion,
                            const EventCategorySet& eventCategories,

--- a/Analysis/source/ProcessAnaTuple.cxx
+++ b/Analysis/source/ProcessAnaTuple.cxx
@@ -1,0 +1,231 @@
+/*! Post-processing of the analysis results.
+This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
+
+#include "hh-bbtautau/Analysis/include/EventAnalyzerCore.h"
+#include "hh-bbtautau/Analysis/include/AnaTuple.h"
+#include "hh-bbtautau/Analysis/include/EventAnalyzerDataCollection.h"
+#include "hh-bbtautau/Analysis/include/StackedPlotsProducer.h"
+#include "hh-bbtautau/Analysis/include/LimitsInputProducer.h"
+
+namespace analysis {
+
+struct AnalyzerArguments : CoreAnalyzerArguments {
+    REQ_ARG(Channel, channel);
+    REQ_ARG(std::string, input);
+    REQ_ARG(std::string, output);
+    OPT_ARG(bool, shapes, true);
+    OPT_ARG(bool, draw, true);
+    OPT_ARG(std::string, vars, "");
+};
+
+class ProcessAnaTuple : public EventAnalyzerCore {
+public:
+    using AnaData = ::analysis::EventAnalyzerData;
+    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection;
+    using PlotsProducer = ::analysis::StackedPlotsProducer;
+
+    ProcessAnaTuple(const AnalyzerArguments& _args) :
+        EventAnalyzerCore(_args, _args.channel()), args(_args), activeVariables(ParseVarSet(args.vars())),
+        tupleReader(args.input(), args.channel(), activeVariables),
+        outputFile(root_ext::CreateRootFile(args.output() + "_full.root"))
+    {
+
+        histConfig.Parse(ana_setup.hist_cfg);
+    }
+
+    void Run()
+    {
+        const std::set<std::string> signal_names(ana_setup.signals.begin(), ana_setup.signals.end());
+        const auto samplesToDraw = PlotsProducer::CreateOrderedSampleCollection(
+                    ana_setup.draw_sequence, sample_descriptors, cmb_sample_descriptors, ana_setup.signals,
+                    ana_setup.data, args.channel());
+
+        for(const auto& subCategory : EventSubCategoriesToProcess()) {
+            std::cout << subCategory << std::endl;
+            AnaDataCollection anaDataCollection(outputFile, channelId, &tupleReader.GetAnaTuple(), activeVariables,
+                                                histConfig.GetItems());
+            std::cout << "\tCreating histograms..." << std::endl;
+            ProduceHistograms(anaDataCollection, subCategory);
+            std::cout << "\tProcessing combined samples... " << std::endl;
+            ProcessCombinedSamples(anaDataCollection, subCategory, ana_setup.cmb_samples);
+            for(const auto& sample : sample_descriptors) {
+                if(sample.second.sampleType == SampleType::QCD) {
+                    std::cout << "\tEstimating QCD..." << std::endl;
+                    EstimateQCD(anaDataCollection, subCategory, sample.second);
+                    break;
+                }
+//                std::cout << "\t\t\t" << hist.first << " -> " << entry.Name() << ", "
+//                          << subDataId << ", " << anaDataId << std::endl;
+
+            }
+
+            if(args.shapes()) {
+                std::cout << "\tProducing inputs for limits..." << std::endl;
+                LimitsInputProducer limitsInputProducer(anaDataCollection, sample_descriptors, cmb_sample_descriptors);
+                for(const std::string& hist_name : ana_setup.final_variables) {
+                    if(!activeVariables.count(hist_name)) continue;
+                    limitsInputProducer.Produce(args.output(), hist_name, ana_setup.limit_categories, subCategory,
+                                                ana_setup.energy_scales, EventRegionsToProcess());
+                }
+            }
+
+            if(args.draw()) {
+                std::cout << "\tCreating plots..." << std::endl;
+                PlotsProducer plotsProducer(anaDataCollection, samplesToDraw, false, true);
+                const std::string pdf_prefix = args.output() + "_" + ToString(subCategory);
+                plotsProducer.PrintStackedPlots(pdf_prefix, EventRegion::SignalRegion(), EventCategoriesToProcess(),
+                                                {subCategory}, signal_names);
+            }
+        }
+
+        std::cout << "Saving output file..." << std::endl;
+    }
+
+private:
+
+    void ProduceHistograms(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory)
+    {
+        auto& tuple = tupleReader.GetAnaTuple();
+        for(Long64_t entryIndex = 0; entryIndex < tuple.GetEntries(); ++entryIndex) {
+            tuple.GetEntry(entryIndex);
+            for(size_t n = 0; n < tuple().dataIds.size(); ++n) {
+                const auto& dataId = tupleReader.GetDataIdByIndex(n);
+                if(dataId.Get<EventSubCategory>() != subCategory) continue;
+                tupleReader.UpdateSecondaryBranches(n);
+                anaDataCollection.Fill(dataId, tuple().weight);
+            }
+        }
+    }
+
+    void EstimateQCD(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory,
+                     const SampleDescriptor& qcd_sample)
+    {
+        static const EventRegionSet sidebandRegions = {
+            EventRegion::OS_AntiIsolated(), EventRegion::SS_Isolated(), EventRegion::SS_AntiIsolated(),
+            EventRegion::SS_LooseIsolated()
+        };
+        static const EventEnergyScaleSet qcdEnergyScales = { EventEnergyScale::Central };
+        const EventSubCategorySet subCategories = { subCategory };
+
+        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
+                subCategories, sidebandRegions, qcdEnergyScales)) {
+            const auto qcdAnaDataId = metaDataId.Set(qcd_sample.name);
+            auto& qcdAnaData = anaDataCollection.Get(qcdAnaDataId);
+            for(const auto& sample_name : sample_descriptors) {
+                const SampleDescriptor& sample =  sample_name.second;
+                if(sample.sampleType == SampleType::QCD) continue;
+                if(ana_setup.IsSignal(sample.name)) continue;
+                double factor = sample.sampleType == SampleType::Data ? +1 : -1;
+                for(const auto& sample_wp : sample.working_points) {
+                    const auto anaDataId = metaDataId.Set(sample_wp.full_name);
+                    auto& anaData = anaDataCollection.Get(anaDataId);
+                    for(const auto& sub_entry : anaData.template GetEntriesEx<TH1D>()) {
+                        auto& entry = qcdAnaData.template GetEntryEx<TH1D>(sub_entry.first);
+                        for(const auto& hist : sub_entry.second->GetHistograms()) {
+                            entry(hist.first).Add(hist.second.get(), factor);
+                        }
+                    }
+                }
+            }
+        }
+
+        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
+                subCategories, qcdEnergyScales)) {
+            const auto anaDataId = metaDataId.Set(qcd_sample.name);
+            auto& osIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_Isolated()));
+            auto& ssIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_Isolated()));
+            auto& ssLooseIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_LooseIsolated()));
+            auto& osAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
+            auto& ssAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
+            for(const auto& sub_entry : ssIsoData.template GetEntriesEx<TH1D>()) {
+                auto& entry_osIso = osIsoData.template GetEntryEx<TH1D>(sub_entry.first);
+                auto& entry_ss_looseIso = ssLooseIsoData.template GetEntryEx<TH1D>(sub_entry.first);
+                auto& entry_osAntiIso = osAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
+                auto& entry_ssAntiIso = ssAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
+                for(const auto& hist : sub_entry.second->GetHistograms()) {
+                    std::string debug_info, negative_bins_info;
+                    if(!FixNegativeContributions(*hist.second,debug_info, negative_bins_info)) continue;
+                    const auto osAntiIso_integral = analysis::Integral(entry_osAntiIso(hist.first), true);
+                    const auto ssAntiIso_integral = analysis::Integral(entry_ssAntiIso(hist.first), true);
+                    if (osAntiIso_integral.GetValue() <= 0){
+                        std::cout << "Warning: OS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
+                        continue;
+                    }
+
+                    if (ssAntiIso_integral.GetValue() <= 0){
+                        std::cout << "Warning: SS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
+                        continue;
+                    }
+                    const double k_factor = osAntiIso_integral.GetValue()/ssAntiIso_integral.GetValue();
+                    const auto ssIso_integral = analysis::Integral(*hist.second, true);
+                    if (ssIso_integral.GetValue() <= 0){
+                        std::cout << "Warning: SS Iso integral less or equal 0 for " << hist.first << std::endl;
+                        continue;
+                    }
+                    const double total_yield = ssIso_integral.GetValue() * k_factor;
+                    entry_osIso(hist.first).CopyContent(entry_ss_looseIso(hist.first));
+                    analysis::RenormalizeHistogram(entry_osIso(hist.first),total_yield,true);
+
+
+                }
+            }
+        }
+    }
+
+    void ProcessCombinedSamples(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory,
+                                const std::vector<std::string>& sample_names)
+    {
+
+        for(const std::string& sample_name : sample_names) {
+            if(!cmb_sample_descriptors.count(sample_name))
+                throw exception("Combined sample '%1%' not found.") % sample_name;
+            CombinedSampleDescriptor& sample = cmb_sample_descriptors.at(sample_name);
+            if(sample.channels.size() && !sample.channels.count(channelId)) continue;
+            std::cout << "\t\t" << sample.name << std::endl;
+            for(const std::string& sub_sample_name : sample.sample_descriptors) {
+                if(!sample_descriptors.count(sub_sample_name))
+                    throw exception("Unable to create '%1%': sub-sample '%2%' not found.")
+                        % sample_name % sub_sample_name;
+                SampleDescriptor& sub_sample =  sample_descriptors.at(sub_sample_name);
+                AddSampleToCombined(anaDataCollection, subCategory, sample, sub_sample);
+            }
+        }
+    }
+
+    void AddSampleToCombined(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory,
+                             CombinedSampleDescriptor& sample, SampleDescriptor& sub_sample)
+    {
+        for(const EventAnalyzerDataId& metaDataId : EventAnalyzerDataId::MetaLoop(EventCategoriesToProcess(),
+                EventRegionsToProcess(), ana_setup.energy_scales)) {
+            const auto anaDataId = metaDataId.Set(sample.name).Set(subCategory);
+            auto& anaData = anaDataCollection.Get(anaDataId);
+            for(const auto& sub_sample_wp : sub_sample.working_points) {
+                const auto subDataId = metaDataId.Set(sub_sample_wp.full_name).Set(subCategory);
+                auto& subAnaData = anaDataCollection.Get(subDataId);
+                for(const auto& sub_entry : subAnaData.GetEntriesEx<TH1D>()) {
+                    auto& entry = anaData.GetEntryEx<TH1D>(sub_entry.first);
+                    for(const auto& hist : sub_entry.second->GetHistograms()) {
+                        entry(hist.first).Add(hist.second.get(), 1);
+                    }
+                }
+            }
+        }
+    }
+
+    static std::set<std::string> ParseVarSet(const std::string& active_vars_str)
+    {
+        const auto list = SplitValueList(active_vars_str, false, ", \t", true);
+        return std::set<std::string>(list.begin(), list.end());
+    }
+
+private:
+    AnalyzerArguments args;
+    std::set<std::string> activeVariables;
+    bbtautau::AnaTupleReader tupleReader;
+    std::shared_ptr<TFile> outputFile;
+    PropertyConfigReader histConfig;
+};
+
+} // namespace analysis
+
+PROGRAM_MAIN(analysis::ProcessAnaTuple, analysis::AnalyzerArguments)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,24 @@ add_library(HHKinFit2 STATIC ${HH_KINFIT2_SRC})
 target_include_directories(HHKinFit2 PRIVATE "${CMSSW_BASE_SRC}/HHKinFit2/HHKinFit2/interface")
 set_source_files_properties(${HH_KINFIT2_SRC} PROPERTIES COMPILE_FLAGS "-w")
 
+set(PrecompHeader "${PROJECT_SOURCE_DIR}/Run/include/Precompiled.h")
+set(PrecompHeaderOut "${PROJECT_SOURCE_DIR}/Run/include/Precompiled.h.pch")
+string (REPLACE " " ";" PchFlags ${CMAKE_CXX_FLAGS})
+get_property(PchIncludeRaw DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+set(PchInclude "")
+foreach(dir ${PchIncludeRaw})
+    set(PchInclude "${PchInclude};-I${dir}")
+endforeach()
+add_custom_command(OUTPUT "${PrecompHeaderOut}"
+                   COMMAND ${CMAKE_CXX_COMPILER} -x c++-header -w ${PchFlags} ${PchInclude} "${PrecompHeader}"  -o "${PrecompHeaderOut}"
+                   IMPLICIT_DEPENDS CXX "${PrecompHeader}"
+                   VERBATIM)
+add_custom_target(GeneratePch DEPENDS "${PrecompHeaderOut}")
+
 foreach(exe_name ${EXE_LIST})
     target_link_libraries("${exe_name}" HTT-utilities HHKinFit2)
+    add_dependencies("${exe_name}" GeneratePch)
+    target_compile_options("${exe_name}" BEFORE PRIVATE "-include;${PrecompHeader}")
 endforeach()
 
 set_target_properties(LimitConfigurationProducer BjetSelectionStudy BjetEffSF KinFitStudy PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/Print/source/Print_Stack.cxx
+++ b/Print/source/Print_Stack.cxx
@@ -2,157 +2,61 @@
 This file is part of https://github.com/hh-italian-group/h-tautau. */
 
 #include "AnalysisTools/Run/include/program_main.h"
-#include "hh-bbtautau/Analysis/include/SampleDescriptorConfigEntryReader.h"
+#include "hh-bbtautau/Analysis/include/EventAnalyzerCore.h"
 #include "hh-bbtautau/Analysis/include/StackedPlotsProducer.h"
-
-struct Arguments {
-    REQ_ARG(std::string, setup);
-    REQ_ARG(std::string, sources);
-    REQ_ARG(std::string, input);
-    REQ_ARG(std::string, output);
-    REQ_ARG(analysis::Channel, channel);
-    REQ_ARG(std::string, hists);
-    OPT_ARG(std::string, mva_setup, "");
-};
 
 namespace analysis {
 
-class PrintStackBase {
-public:
-    virtual ~PrintStackBase() {}
-    virtual void Run() = 0;
+struct Arguments : CoreAnalyzerArguments {
+    REQ_ARG(std::string, input);
+    REQ_ARG(std::string, output);
+    REQ_ARG(Channel, channel);
+    REQ_ARG(std::string, vars);
 };
 
-template<typename _FirstLeg, typename _SecondLeg>
-class PrintStackT : public PrintStackBase {
+class PrintStack : public EventAnalyzerCore {
 public:
-    using FirstLeg = _FirstLeg;
-    using SecondLeg = _SecondLeg;
-    using AnaData = ::analysis::EventAnalyzerData<FirstLeg, SecondLeg>;
-    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection<AnaData>;
-    using PlotsProducer = ::analysis::StackedPlotsProducer<FirstLeg, SecondLeg>;
+    using AnaData = ::analysis::EventAnalyzerData;
+    using AnaDataCollection = ::analysis::EventAnalyzerDataCollection;
+    using PlotsProducer = ::analysis::StackedPlotsProducer;
 
-    static const EventCategorySet& EventCategoriesToProcess()
+    PrintStack(const Arguments& _args) :
+        EventAnalyzerCore(_args, _args.channel()), args(_args), inputFile(root_ext::OpenRootFile(args.input())),
+        vars(ParseVarSet(args.vars()))
     {
-        static const EventCategorySet categories = {
-            EventCategory::TwoJets_Inclusive(), EventCategory::TwoJets_ZeroBtag_Resolved(),
-            EventCategory::TwoJets_OneBtag_Resolved(), EventCategory::TwoJets_TwoBtag_Resolved(),
-            EventCategory::TwoJets_TwoLooseBtag_Boosted()
-        };
-        return categories;
+        histConfig.Parse(ana_setup.hist_cfg);
+        anaDataCollection = std::make_shared<AnaDataCollection>(inputFile, args.channel(), nullptr, vars,
+                                                                histConfig.GetItems());
     }
 
-    PrintStackT(const Arguments& _args) :
-        args(_args), anaDataCollection(args.input())
-    {
-        ConfigReader config_reader;
-
-        AnalyzerSetupCollection ana_setup_collection;
-        AnalyzerConfigEntryReader ana_entry_reader(ana_setup_collection);
-        config_reader.AddEntryReader("ANA_DESC", ana_entry_reader, false);
-
-        MvaReaderSetupCollection mva_setup_collection;
-        MvaReaderSetupEntryReader mva_entry_reader(mva_setup_collection);
-        config_reader.AddEntryReader("MVA", mva_entry_reader, false);
-
-        SampleDescriptorConfigEntryReader sample_entry_reader(sample_descriptors);
-        config_reader.AddEntryReader("SAMPLE", sample_entry_reader, true);
-
-        CombinedSampleDescriptorConfigEntryReader combined_entry_reader(cmb_sample_descriptors, sample_descriptors);
-        config_reader.AddEntryReader("SAMPLE_CMB", combined_entry_reader, false);
-
-        config_reader.ReadConfig(args.sources());
-
-        if(!ana_setup_collection.count(args.setup()))
-            throw exception("Setup '%1%' not found in the configuration file '%2%'.") % args.setup() % args.sources();
-        ana_setup = ana_setup_collection.at(args.setup());
-
-        if(args.mva_setup().size()) {
-            if(!mva_setup_collection.count(args.mva_setup()))
-                throw exception("MVA setup '%1%' not found.") % args.mva_setup();
-            mva_setup = mva_setup_collection.at(args.mva_setup());
-        }
-
-        CreateEventSubCategoriesToProcess();
-        const std::vector<std::string> hist_list = SplitValueList(args.hists(), false, ", ", true);
-        hist_names.insert(hist_list.begin(), hist_list.end());
-    }
-
-    virtual void Run() override
+    void Run()
     {
         std::cout << "Creating plots..." << std::endl;
+        const std::set<std::string> signal_names(ana_setup.signals.begin(), ana_setup.signals.end());
         const auto samplesToDraw = PlotsProducer::CreateOrderedSampleCollection(
                     ana_setup.draw_sequence, sample_descriptors, cmb_sample_descriptors, ana_setup.signals,
-                    ana_setup.data);
-        PlotsProducer plotsProducer(anaDataCollection, samplesToDraw, false, true, hist_names);
-        const std::set<std::string> signal_names(ana_setup.signals.begin(), ana_setup.signals.end());
+                    ana_setup.data, channelId);
+
+        PlotsProducer plotsProducer(*anaDataCollection, samplesToDraw, false, true, vars);
         plotsProducer.PrintStackedPlots(args.output(), EventRegion::SignalRegion(), EventCategoriesToProcess(),
                                         sub_categories_to_process, signal_names);
     }
 
 private:
-    void CreateEventSubCategoriesToProcess()
+    static std::set<std::string> ParseVarSet(const std::string& active_vars_str)
     {
-        const auto base = EventSubCategory().SetCutResult(SelectionCut::mh, true);
-        sub_categories_to_process.insert(base);
-        if(mva_setup.is_initialized()) {
-            for(const auto& mva_sel : mva_setup->selections) {
-                auto sub_category = EventSubCategory(base).SetCutResult(mva_sel.first, true);
-                sub_categories_to_process.insert(sub_category);
-            }
-        }
+        const auto list = SplitValueList(active_vars_str, false, ", \t", true);
+        return std::set<std::string>(list.begin(), list.end());
     }
 
 private:
     Arguments args;
-    AnaDataCollection anaDataCollection;
-    AnalyzerSetup ana_setup;
-    boost::optional<MvaReaderSetup> mva_setup;
-    SampleDescriptorCollection sample_descriptors;
-    CombinedSampleDescriptorCollection cmb_sample_descriptors;
-    EventSubCategorySet sub_categories_to_process;
-    std::set<std::string> hist_names;
-};
-
-class PrintStack {
-public:
-    PrintStack(const Arguments& _args) : print_base(MakePrintStack(_args)) {}
-
-    void Run()
-    {
-        print_base->Run();
-    }
-
-private:
-    template<int channel_id>
-    static std::shared_ptr<PrintStackBase> MakePrintStackForChannel(const Arguments& args)
-    {
-        using LegInfo = ChannelLegInfo<channel_id>;
-        using FirstLeg = typename LegInfo::FirstLeg;
-        using SecondLeg = typename LegInfo::SecondLeg;
-        using PrintStackClass = PrintStackT<FirstLeg, SecondLeg>;
-        return std::make_shared<PrintStackClass>(args);
-    }
-
-    static std::shared_ptr<PrintStackBase> MakePrintStack(const Arguments& args)
-    {
-        using MakeFn = std::shared_ptr<PrintStackBase> (*)(const Arguments&);
-        static std::map<Channel, MakeFn> makers = {
-            { Channel::ETau, &MakePrintStackForChannel<static_cast<int>(Channel::ETau)> },
-            { Channel::MuTau, &MakePrintStackForChannel<static_cast<int>(Channel::MuTau)> },
-            { Channel::TauTau, &MakePrintStackForChannel<static_cast<int>(Channel::TauTau)> },
-            { Channel::MuMu, &MakePrintStackForChannel<static_cast<int>(Channel::MuMu)> }
-        };
-        const Channel channel = args.channel();
-        if(!makers.count(channel))
-            throw exception("Unsupported channel '%1%'.") % channel;
-        return makers.at(channel)(args);
-    }
-
-private:
-    std::shared_ptr<PrintStackBase> print_base;
+    std::shared_ptr<TFile> inputFile;
+    std::set<std::string> vars;
+    PropertyConfigReader histConfig;
+    std::shared_ptr<AnaDataCollection> anaDataCollection;
 };
 
 } // namespace analysis
 
-PROGRAM_MAIN(analysis::PrintStack, Arguments)
+PROGRAM_MAIN(analysis::PrintStack, analysis::Arguments)

--- a/Run/include/Precompiled.h
+++ b/Run/include/Precompiled.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <algorithm>
+#include <bitset>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <type_traits>
+#include <typeinfo>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <random>
+#include <set>
+#include <string>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <tuple>
+#include <unordered_set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+
+#include <boost/algorithm/string.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/bimap.hpp>
+#include <boost/crc.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/math/constants/constants.hpp>
+#include <boost/math/distributions.hpp>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/math/special_functions/hermite.hpp>
+#include <boost/math/tools/roots.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/preprocessor/seq.hpp>
+#include <boost/preprocessor/variadic.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/regex.hpp>
+#include <boost/thread/thread.hpp>
+
+
+#include <Compression.h>
+#include <Math/PtEtaPhiE4D.h>
+#include <Math/PtEtaPhiM4D.h>
+#include <Math/PxPyPzE4D.h>
+#include <Math/LorentzVector.h>
+#include <Math/SMatrix.h>
+#include <Math/VectorUtil.h>
+#include <Rtypes.h>
+#include <TAttText.h>
+#include <TBox.h>
+#include <TBranch.h>
+#include <TCanvas.h>
+#include <TChain.h>
+#include <TClass.h>
+#include <TColor.h>
+#include <TError.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TFrame.h>
+#include <TGraph.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <THStack.h>
+#include <TKey.h>
+#include <TLatex.h>
+#include <TLegend.h>
+#include <TLine.h>
+#include <TLorentzVector.h>
+#include <TMatrixD.h>
+#include <TMVA/Reader.h>
+#include <TObject.h>
+#include <TPad.h>
+#include <TPaveText.h>
+#include <TPaveStats.h>
+#include <TPaveLabel.h>
+#include <TProfile.h>
+#include <TROOT.h>
+#include <TString.h>
+#include <TStyle.h>
+#include <TSystem.h>
+#include <TText.h>
+#include <TTree.h>
+#include <TVector3.h>
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- Analysis/config/histograms.cfg: new definition of histograms using PropertyConfig.
- AnaTuple: tuple to store unbinned analyzer output.
- Code from BaseEventAnalyzer are split into EventAnalyzerCore and ProcessAnaTuple.
- *Analyzer now producing AnaTuple as the output.
- EventAnalyzerData: load histograms from the config.
- EventAnalyzerDataId: moved into separate file.
- EventAnalyzerDataCollection: modified to use PropertyConfig.
- ProcessAnaTuple: create all histograms, plots and shapes for limits from  AnaTuple.
- LimitsInputProducer and StackedPlotsProducer are no longer template.
- Print_Stack: modified to work with new EventAnalyzerDataCollection.
- CMakeLists.txt, Run/include/Precompiled.h: introduced precompiled headers to increase compilation speed.