### PR TITLE
Various bug fixes and improvements.

### DIFF
--- a/Analysis/config/histograms.cfg
+++ b/Analysis/config/histograms.cfg
@@ -21,12 +21,12 @@ mva_score/muTau: x_bins="-1 -0.9 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0
                  x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.2
 mva_score/muTau/2jets2LoosebtagB: x_bins="-1 0.6 0.8 0.9 1" x_title="MVA score" y_title="dN / bin width" \
                                   log_y=false max_y_sf=2
-mva_score/tauTau: x_bins="-1 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1" \
-                  x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.4
-mva_score/tauTau/2jets2btagR: x_bins="-1 -0.8 -0.6 -0.3 0.1 0.4 0.7 0.85 1" \
-                        x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.4
-mva_score/tauTau/2jets2LoosebtagB: x_bins="-1 0 0.6 0.8 1" x_title="MVA score" y_title="dN / bin width" \
-                                   log_y=false max_y_sf=2
+mva_score/tauTau: x_bins="0 0.05 0.1 0.3 0.5 0.7 0.85 0.95 1" \
+                  x_title="MVA score" y_title="dN / bin width" log_y=true max_y_sf=400
+mva_score/tauTau/2jets2btagR: x_bins="0 0.025 0.05 0.1 0.3 0.5 0.7 0.85 0.95 1" \
+                        x_title="MVA score" y_title="dN / bin width" log_y=true max_y_sf=40
+mva_score/tauTau/2jets2LoosebtagB: x_bins="0 0.8 0.9 0.95 1" x_title="MVA score" y_title="dN / bin width" \
+                                   log_y=true max_y_sf=40
 
 
 mt_tot: x_range=0:500/25 x_title="M_{T}^{TOT}(GeV)" y_title="Events" max_y_sf=1.5

--- a/Analysis/config/histograms.cfg
+++ b/Analysis/config/histograms.cfg
@@ -12,15 +12,14 @@ MT2/tauTau: x_bins="0 25 50 75 100 125 150 200 250 300 500" x_title="MT2_{H} (Ge
 MT2/tauTau/2jets2LoosebtagB: x_bins="0 150 500" x_title="MT2_{H} (GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
 
 mva_score: x_range=-1:1/40 x_title="MVA score" y_title="Events" log_y=true max_y_sf=1.8
-mva_score/eTau: x_bins="-1 -0.9 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1" \
-                x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.2
-mva_score/eTau/2jets2LoosebtagB: x_bins="-1 0.6 0.8 1" x_title="MVA score" y_title="dN / bin width" \
-                                 log_y=false max_y_sf=2
-mva_score/muTau: x_bins="-1 -0.9 -0.8 -0.7 -0.6 -0.5 -0.4 -0.3 -0.2 -0.1 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.85 0.9 \
-                         0.95 1" \
-                 x_title="MVA score" y_title="dN / bin width" log_y=false max_y_sf=1.2
-mva_score/muTau/2jets2LoosebtagB: x_bins="-1 0.6 0.8 0.9 1" x_title="MVA score" y_title="dN / bin width" \
-                                  log_y=false max_y_sf=2
+mva_score/eTau: x_bins="0 0.05 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 0.95 0.975 1" \
+                x_title="MVA score" y_title="dN / bin width" log_y=true max_y_sf=400
+mva_score/eTau/2jets2LoosebtagB: x_bins="0 0.8 0.9 0.95 0.975 1" x_title="MVA score" y_title="dN / bin width" \
+                                 log_y=true max_y_sf=400
+mva_score/muTau: x_bins="0 0.05 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 0.95 0.975 1" \
+                 x_title="MVA score" y_title="dN / bin width" log_y=true max_y_sf=400
+mva_score/muTau/2jets2LoosebtagB: x_bins="0 0.8 0.9 0.95 0.975 1" x_title="MVA score" y_title="dN / bin width" \
+                                  log_y=true max_y_sf=400
 mva_score/tauTau: x_bins="0 0.05 0.1 0.3 0.5 0.7 0.85 0.95 1" \
                   x_title="MVA score" y_title="dN / bin width" log_y=true max_y_sf=400
 mva_score/tauTau/2jets2btagR: x_bins="0 0.025 0.05 0.1 0.3 0.5 0.7 0.85 0.95 1" \

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -382,7 +382,7 @@ struct EventSubCategory {
     EventSubCategory& SetCutResult(SelectionCut cut, bool result)
     {
         if(HasCut(cut))
-            throw exception("Cut '%1%' is aready defined.") % cut;
+            throw exception("Cut '%1%' is already defined.") % cut;
         const size_t index = GetIndex(cut);
         const BitsContainer mask = BitsContainer(1) << index;
         results = (results & ~mask) | (BitsContainer(result) << index);

--- a/Analysis/include/EventAnalyzerCore.h
+++ b/Analysis/include/EventAnalyzerCore.h
@@ -106,6 +106,8 @@ private:
         sub_categories_to_process.insert(ana_setup.sub_categories.begin(), ana_setup.sub_categories.end());
         if(mva_setup.is_initialized()) {
             for(const auto& base : ana_setup.sub_categories) {
+                SelectionCut predefined_cut;
+                if(base.TryGetLastMvaCut(predefined_cut)) continue;
                 for(const auto& mva_sel : mva_setup->selections) {
                     auto param = mva_sel.second;
                     std::cout<<"Selection cut: "<<mva_sel.first<<" - name: "<<param.name

--- a/Analysis/include/LimitsInputProducer.h
+++ b/Analysis/include/LimitsInputProducer.h
@@ -41,6 +41,21 @@ public:
         return full_name.str();
     }
 
+    static std::string EventRegionSuffix(EventRegion region)
+    {
+        static const std::map<EventRegion, std::string> regions {
+            { EventRegion::OS_AntiIsolated(), "_OS_antiiso" },
+            { EventRegion::SS_AntiIsolated(), "_SS_antiiso" },
+            { EventRegion::SS_Isolated(), "_SS_iso" },
+        };
+
+        if(region == EventRegion::SignalRegion())
+            return "";
+        if(regions.count(region))
+            return regions.at(region);
+        return "_" + ToString(region);
+    }
+
     template<typename ...Args>
     LimitsInputProducer(AnaDataCollection& _anaDataCollection, Args&&... sample_descriptors) :
         anaDataCollection(&_anaDataCollection)
@@ -67,9 +82,8 @@ public:
         for(const EventAnalyzerDataId& metaId : EventAnalyzerDataId::MetaLoop(eventCategories, eventEnergyScales,
                                                                               sampleWorkingPoints, eventRegions))
         {
-            std::string directoryName = dirNamePrefix + eventCategories.at(metaId.Get<EventCategory>());
-            if(metaId.Get<EventRegion>() != EventRegion::SignalRegion())
-                directoryName += "_" + ToString(metaId.Get<EventRegion>());
+            const std::string directoryName = dirNamePrefix + eventCategories.at(metaId.Get<EventCategory>())
+                    + EventRegionSuffix(metaId.Get<EventRegion>());
             TDirectory* directory = root_ext::GetDirectory(*outputFile, directoryName, true);
             const SampleWP& sampleWP = sampleWorkingPoints.at(metaId.Get<std::string>());
             const auto anaDataId = metaId.Set(eventSubCategory).Set(metaId.Get<EventRegion>());
@@ -101,9 +115,9 @@ public:
             of.exceptions(std::ios::failbit);
             for(const auto& id : empty_histograms)
                 of << id << "\n";
-            std::cout << "\t\tWarning: some datacard histograms are empty.\n"
-                      << "\t\tThey are replaced with histograms with a tiny yield in the central bin.\n"
-                      << "\t\tSee '" << of_name << "' for details." << std::endl;
+            std::cout << "\t\t\tWarning: some datacard histograms are empty.\n"
+                      << "\t\t\tThey are replaced with histograms with a tiny yield in the central bin.\n"
+                      << "\t\t\tSee '" << of_name << "' for details." << std::endl;
         }
     }
 

--- a/Analysis/source/ProcessAnaTuple.cxx
+++ b/Analysis/source/ProcessAnaTuple.cxx
@@ -16,6 +16,7 @@ struct AnalyzerArguments : CoreAnalyzerArguments {
     OPT_ARG(bool, shapes, true);
     OPT_ARG(bool, draw, true);
     OPT_ARG(std::string, vars, "");
+    OPT_ARG(size_t, n_parallel, 10);
 };
 
 class ProcessAnaTuple : public EventAnalyzerCore {
@@ -39,38 +40,56 @@ public:
                     ana_setup.draw_sequence, sample_descriptors, cmb_sample_descriptors, ana_setup.signals,
                     ana_setup.data, args.channel());
 
-        for(const auto& subCategory : sub_categories_to_process) {
-            std::cout << subCategory << std::endl;
+        std::ofstream qcd_out(args.output() +"_QCD.txt");
+
+        const std::vector<EventSubCategory> all_subCategories(sub_categories_to_process.begin(),
+                                                              sub_categories_to_process.end());
+
+        for(size_t n = 0; n * args.n_parallel() < all_subCategories.size(); ++n) {
             AnaDataCollection anaDataCollection(outputFile, channelId, &tupleReader.GetAnaTuple(), activeVariables,
                                                 histConfig.GetItems());
+            EventSubCategorySet subCategories;
+            for(size_t k = 0; k < args.n_parallel() && n * args.n_parallel() + k < all_subCategories.size(); ++k) {
+                const auto& subCategory = all_subCategories.at(n * args.n_parallel() + k);
+                subCategories.insert(subCategory);
+                std::cout << subCategory << " ";
+            }
+            std::cout << std::endl;
+
             std::cout << "\tCreating histograms..." << std::endl;
-            ProduceHistograms(anaDataCollection, subCategory);
-            std::cout << "\tProcessing combined samples... " << std::endl;
-            ProcessCombinedSamples(anaDataCollection, subCategory, ana_setup.cmb_samples);
-            for(const auto& sample : sample_descriptors) {
-                if(sample.second.sampleType == SampleType::QCD) {
-                    std::cout << "\tEstimating QCD..." << std::endl;
-                    EstimateQCD(anaDataCollection, subCategory, sample.second);
-                    break;
+            ProduceHistograms(anaDataCollection, subCategories);
+
+            std::cout << "\tProcessing combined samples and QCD... " << std::endl;
+            for(const auto& subCategory : subCategories) {
+                ProcessCombinedSamples(anaDataCollection, subCategory, ana_setup.cmb_samples);
+                for(const auto& sample : sample_descriptors) {
+                    if(sample.second.sampleType == SampleType::QCD) {
+                        EstimateQCD(anaDataCollection, subCategory, sample.second, qcd_out);
+                        break;
+                    }
                 }
             }
 
             if(args.shapes()) {
-                std::cout << "\tProducing inputs for limits..." << std::endl;
-                LimitsInputProducer limitsInputProducer(anaDataCollection, sample_descriptors, cmb_sample_descriptors);
+                std::cout << "\t\tProducing inputs for limits..." << std::endl;
+                LimitsInputProducer limitsInputProducer(anaDataCollection, sample_descriptors,
+                                                        cmb_sample_descriptors);
                 for(const std::string& hist_name : ana_setup.final_variables) {
                     if(!activeVariables.count(hist_name)) continue;
-                    limitsInputProducer.Produce(args.output(), hist_name, ana_setup.limit_categories, subCategory,
-                                                ana_setup.energy_scales, ana_setup.regions);
+                    for(const auto& subCategory : subCategories)
+                        limitsInputProducer.Produce(args.output(), hist_name, ana_setup.limit_categories, subCategory,
+                                                    ana_setup.energy_scales, ana_setup.regions);
                 }
             }
 
             if(args.draw()) {
-                std::cout << "\tCreating plots..." << std::endl;
+                std::cout << "\t\tCreating plots..." << std::endl;
                 PlotsProducer plotsProducer(anaDataCollection, samplesToDraw, false, true);
-                const std::string pdf_prefix = args.output() + "_" + ToString(subCategory);
+                std::string pdf_prefix = args.output();
+                if(n != 0)
+                    pdf_prefix += "_part" + ToString(n + 1);
                 plotsProducer.PrintStackedPlots(pdf_prefix, EventRegion::SignalRegion(), ana_setup.categories,
-                                                {subCategory}, signal_names);
+                                                subCategories, signal_names);
             }
         }
 
@@ -79,22 +98,22 @@ public:
 
 private:
 
-    void ProduceHistograms(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory)
+    void ProduceHistograms(AnaDataCollection& anaDataCollection, const EventSubCategorySet& subCategories)
     {
         auto& tuple = tupleReader.GetAnaTuple();
         for(Long64_t entryIndex = 0; entryIndex < tuple.GetEntries(); ++entryIndex) {
             tuple.GetEntry(entryIndex);
             for(size_t n = 0; n < tuple().dataIds.size(); ++n) {
                 const auto& dataId = tupleReader.GetDataIdByIndex(n);
-                if(dataId.Get<EventSubCategory>() != subCategory) continue;
-                tupleReader.UpdateSecondaryBranches(n);
+                if(!subCategories.count(dataId.Get<EventSubCategory>())) continue;
+                tupleReader.UpdateSecondaryBranches(dataId, n);
                 anaDataCollection.Fill(dataId, tuple().weight);
             }
         }
     }
 
     void EstimateQCD(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory,
-                     const SampleDescriptor& qcd_sample)
+                     const SampleDescriptor& qcd_sample, std::ostream& log)
     {
         static const EventRegionSet sidebandRegions = {
             EventRegion::OS_AntiIsolated(), EventRegion::SS_Isolated(), EventRegion::SS_AntiIsolated(),
@@ -132,40 +151,46 @@ private:
             auto& ssIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_Isolated()));
             auto& ssLooseIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_LooseIsolated()));
             auto& osAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
-            auto& ssAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::OS_AntiIsolated()));
+            auto& ssAntiIsoData = anaDataCollection.Get(anaDataId.Set(EventRegion::SS_AntiIsolated()));
             for(const auto& sub_entry : ssIsoData.template GetEntriesEx<TH1D>()) {
                 auto& entry_osIso = osIsoData.template GetEntryEx<TH1D>(sub_entry.first);
                 auto& entry_ss_looseIso = ssLooseIsoData.template GetEntryEx<TH1D>(sub_entry.first);
                 auto& entry_osAntiIso = osAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
                 auto& entry_ssAntiIso = ssAntiIsoData.template GetEntryEx<TH1D>(sub_entry.first);
                 for(const auto& hist : sub_entry.second->GetHistograms()) {
+                    log << anaDataId << ": " << sub_entry.first << " " << hist.first << "\n";
                     std::string debug_info, negative_bins_info;
-                    if(!FixNegativeContributions(*hist.second,debug_info, negative_bins_info)) continue;
-                    const auto osAntiIso_integral = analysis::Integral(entry_osAntiIso(hist.first), true);
-                    const auto ssAntiIso_integral = analysis::Integral(entry_ssAntiIso(hist.first), true);
-                    if (osAntiIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: OS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
+                    if(!FixNegativeContributions(*hist.second,debug_info, negative_bins_info)) {
+                        log << debug_info << "\n" << negative_bins_info << "\n";
+                        continue;
+                    }
+                    const auto osAntiIso_integral = Integral(entry_osAntiIso(hist.first), true);
+                    const auto ssAntiIso_integral = Integral(entry_ssAntiIso(hist.first), true);
+                    if (osAntiIso_integral.GetValue() <= 0 || osAntiIso_integral.IsCompatible(PhysicalValue::Zero)){
+                        log << "Warning: OS Anti Iso integral is too small " << hist.first << std::endl;
                         continue;
                     }
 
-                    if (ssAntiIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: SS Anti Iso integral less or equal 0 for " << hist.first << std::endl;
+                    if (ssAntiIso_integral.GetValue() <= 0 || ssAntiIso_integral.IsCompatible(PhysicalValue::Zero)){
+                        log << "Warning: SS Anti Iso integral is too small " << hist.first << std::endl;
                         continue;
                     }
-                    const double k_factor = osAntiIso_integral.GetValue()/ssAntiIso_integral.GetValue();
+                    const auto k_factor = osAntiIso_integral / ssAntiIso_integral;
                     const auto ssIso_integral = analysis::Integral(*hist.second, true);
                     if (ssIso_integral.GetValue() <= 0){
-                        std::cout << "Warning: SS Iso integral less or equal 0 for " << hist.first << std::endl;
+                        log << "Warning: SS Iso integral less or equal 0 for " << hist.first << std::endl;
                         continue;
                     }
-                    const double total_yield = ssIso_integral.GetValue() * k_factor;
+                    const auto total_yield = ssIso_integral * k_factor;
+                    log << anaDataId << ": osAntiIso integral = " << osAntiIso_integral
+                        << ", ssAntiIso integral = " << ssAntiIso_integral << ", os/ss sf = " << k_factor
+                        << ", ssIso integral = " << ssIso_integral << ", total yield = " << total_yield << std::endl;
                     entry_osIso(hist.first).CopyContent(entry_ss_looseIso(hist.first));
-                    analysis::RenormalizeHistogram(entry_osIso(hist.first),total_yield,true);
-
-
+                    analysis::RenormalizeHistogram(entry_osIso(hist.first), total_yield.GetValue(), true);
                 }
             }
         }
+        log << std::endl;
     }
 
     void ProcessCombinedSamples(AnaDataCollection& anaDataCollection, const EventSubCategory& subCategory,

--- a/Instruments/config/Skimmer.cfg
+++ b/Instruments/config/Skimmer.cfg
@@ -217,6 +217,7 @@ file: GluGluToHHTo2B2Tau_node_10.root
 
 [Data_SingleElectron]
 apply_common_weights: false
+apply_dm_fix: false
 merged_output: SingleElectron_2016.root
 file: SingleElectron_Run2016B-03Feb2017_ver2-v2.root
 file: SingleElectron_Run2016C-03Feb2017-v1.root
@@ -229,6 +230,7 @@ file: SingleElectron_Run2016H-03Feb2017_ver3-v1.root
 
 [Data_SingleMuon]
 apply_common_weights: false
+apply_dm_fix: false
 merged_output: SingleMuon_2016.root
 file: SingleMuon_Run2016B-03Feb2017_ver2-v2.root
 file: SingleMuon_Run2016C-03Feb2017-v1.root

--- a/Instruments/config/Skimmer.cfg
+++ b/Instruments/config/Skimmer.cfg
@@ -12,6 +12,15 @@ apply_mass_cut: true
 apply_charge_cut: true
 tau_id_cut: byMediumIsolationMVArun2v1DBoldDMwLT 0.5
 
+[SETUP mini_setup : setup_base]
+channels: eTau muTau tauTau
+energy_scales: Central
+apply_mass_cut: false
+apply_charge_cut: true
+tau_id_cut: byMediumIsolationMVArun2v1DBoldDMwLT 0.5
+keep_genJets: true
+keep_genParticles: true
+
 [SETUP mh_setup : setup_base]
 channels: eTau muTau tauTau
 energy_scales: all

--- a/Instruments/config/sync.cfg
+++ b/Instruments/config/sync.cfg
@@ -1,6 +1,6 @@
 input0: name=LLR color=kBlue label_pos=0.65,0.88 label_size=0.03
 input1: name=PI color=kRed label_pos=0.65,0.84 label_size=0.03
-targets: dir_names="(eTau|muTau|tauTau)_(res1b|res2b|boosted)" \
+targets: dir_names="(eTau|muTau|tauTau)_(res1b|res2b|boosted).*" \
          hist_names="DY_[0-2]b EWK QCD TT W WW WZ ZH ZZ data_obs ggh_hh_ttbb_kl1 tW"
 draw_opt: canvas_size=600,600 x_title="MT2" y_title="dN/dm (1/GeV)" axes_title_offsets=1,2.2 div_bw=true \
           margins=0.15,0.3,0.05,0.1 zero_threshold=1e-7 y_ratio_label_size=0.022 \

--- a/Instruments/include/SkimmerConfig.h
+++ b/Instruments/include/SkimmerConfig.h
@@ -71,6 +71,7 @@ struct SkimJob {
     std::string merged_output;
     std::vector<FileDescriptor> files;
     bool apply_common_weights{true};
+    bool apply_dm_fix{true};
     mc_corrections::WeightingMode weights;
 
     bool ProduceMergedOutput() const { return merged_output.size(); }

--- a/Instruments/include/SkimmerConfigEntryReader.h
+++ b/Instruments/include/SkimmerConfigEntryReader.h
@@ -63,6 +63,7 @@ public:
     {
         CheckReadParamCounts("merged_output", 1, Condition::less_equal);
         CheckReadParamCounts("apply_common_weights", 1, Condition::less_equal);
+        CheckReadParamCounts("apply_dm_fix", 1, Condition::less_equal);
         CheckReadParamCounts("weights", 1, Condition::less_equal);
 
         const size_t n_files = GetReadParamCounts("file");
@@ -84,6 +85,7 @@ public:
         ParseEntry("merged_output", current.merged_output);
         ParseFileDescriptor(param_name, param_value);
         ParseEntry("apply_common_weights", current.apply_common_weights);
+        ParseEntry("apply_dm_fix", current.apply_dm_fix);
         ParseEntryList("weights", current.weights);
     }
 

--- a/Instruments/source/BTagEffEstimator.cxx
+++ b/Instruments/source/BTagEffEstimator.cxx
@@ -17,6 +17,7 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 struct Arguments { // list of all program arguments
     REQ_ARG(std::string, output_file);  
     OPT_ARG(std::string, apply_pu_id_cut,"no");
+    OPT_ARG(unsigned, n_threads, 1);
     REQ_ARG(std::vector<std::string>, input_file); 
 };
 
@@ -38,9 +39,13 @@ public:
     using Event = ntuple::Event;
     using EventTuple = ntuple::EventTuple;
 
-    BTagEfficiency(const Arguments& _args) : args(_args), 
-    outfile(root_ext::CreateRootFile(args.output_file()))
+    BTagEfficiency(const Arguments& _args) :
+        args(_args), outfile(root_ext::CreateRootFile(args.output_file()))
     {
+        ROOT::EnableThreadSafety();
+        if(args.n_threads() > 1)
+            ROOT::EnableImplicitMT(args.n_threads());
+
         anaDataMap["All"+eff] = std::make_shared<BTagData>(outfile,tools::FullPath({"All",effMap[eff]}));
         anaDataMap["All"+valCha] = std::make_shared<BTagData>(outfile,tools::FullPath({"All",valMap[valCha]}));
         for(const auto& tau_sign : tau_signs){
@@ -73,6 +78,13 @@ public:
         flavour_names.insert(flavour_all);
         static const std::string num = "Num", denom = "Denom";
 
+        static const std::set<std::string> disabled_branches;
+        static const std::set<std::string> enabled_branches = {
+            "jets_p4", "SVfit_p4", "extramuon_veto", "extraelec_veto", "q_1", "q_2", "tauId_keys_1", "tauId_values_1",
+            "tauId_keys_2", "tauId_values_2", "jets_mva", "jets_csv", "jets_hadronFlavour"
+        };
+
+
         bool apply_pu_id_cut = args.apply_pu_id_cut() != "no";
         DiscriminatorWP pu_wp = DiscriminatorWP::Medium;
         if(apply_pu_id_cut) pu_wp = analysis::Parse<DiscriminatorWP>(args.apply_pu_id_cut());
@@ -82,11 +94,14 @@ public:
                 std::shared_ptr<TFile> in_file(root_ext::OpenRootFile(name));
                 std::shared_ptr<EventTuple> tuple;
                 try {
-                    tuple = ntuple::CreateEventTuple(channel, in_file.get(), true, ntuple::TreeState::Full);
+                    tuple = std::make_shared<EventTuple>(channel, in_file.get(), true, disabled_branches,
+                                                         enabled_branches);
                 } catch(std::exception&) {
                     std::cerr << "WARNING: tree "<<channel<<" not found in file"<<name<< std::endl;
                     continue;
                 }
+
+                std::cout << "Processing " << name << "/" << channel << std::endl;
 
                 for(const Event& event : *tuple){
                     const EventEnergyScale es = static_cast<EventEnergyScale>(event.eventEnergyScale);
@@ -109,8 +124,9 @@ public:
                                         tau_iso_disc_hash, tau_iso_cut);
                     std::string tau_iso = passTauId ? "Iso" : "NonIso";
 
-                    for (size_t i=0; i<2; i++){
+                    for (size_t i = 0; i < event.jets_p4.size(); ++i){
                         const auto& jet = event.jets_p4.at(i);
+                        if(std::abs(jet.eta()) >= cuts::btag_2016::eta) continue;
 
                         //PU correction
                         if(apply_pu_id_cut){

--- a/Instruments/source/TupleSkimmer.cxx
+++ b/Instruments/source/TupleSkimmer.cxx
@@ -209,14 +209,9 @@ private:
                 }
                 std::cout << "\tProcessing";
                 std::vector<std::shared_ptr<TFile>> inputFiles;
-                for(unsigned n = 0; n < desc_iter->inputs.size(); ++n) {
-                    const auto& input = desc_iter->inputs.at(n);
+                for(const auto& input : desc_iter->inputs) {
                     std::cout << " " << input;
                     inputFiles.push_back(root_ext::OpenRootFile(args.inputPath() + "/" + input));
-                    if(n == 0 || !desc_iter->first_input_is_ref) {
-                        summary->file_desc_name.push_back(input);
-                        summary->file_desc_id.push_back(n * 1000 + desc_id);
-                    }
                 }
                 std::cout << "\n\t\textracting summary" << std::endl;
                 double weight_xs, weight_xs_withTopPt;
@@ -226,6 +221,12 @@ private:
                     ntuple::MergeProdSummaries(*summary, desc_summary);
                 else
                     summary = std::make_shared<ProdSummary>(desc_summary);
+
+                for(unsigned n = 0; n < desc_iter->inputs.size() && (n == 0 || !desc_iter->first_input_is_ref); ++n) {
+                    const auto& input = desc_iter->inputs.at(n);
+                    summary->file_desc_name.push_back(input);
+                    summary->file_desc_id.push_back(n * 1000 + desc_id);
+                }
 
                 summary->n_splits = setup.n_splits;
                 summary->split_seed = setup.split_seed;


### PR DESCRIPTION
- histograms.cfg: adjusted mva_score binning
- AnaTuple.h: store range for mva_score and remap values to [0, 1) interval.
- Check for duplicated events moved from BaseEventAnalyzer into TupleSkimmer.
- EventAnalyzerCore: don't add mva sub-categories on top, if base sub-category already contains mva cut.
- LimitsInputProducer: changed naming for sideband regions to be compatible with the legacy shapes.
- ProcessAnaTuple:
  - process several sub-categories in parallel;
  - QCD estimation: fixed bug and added controls for very low yield in the sidebands.
- Skimmer.cfg: added mini_setup (signal region without mass window cut with genJets)
- TupleSkimmer:
  - report summary at the end of the run;
  - store file_desc_id for all files;
  - added possibility to not apply dm_fix (needed to run correctly for ele and mu data).
- BTagEffEstimator:
  - run on all jets in the event in order to avoid bias in btag weight calculation;
  - improved run performance by using multiple thread while reading root tree, and by enabling only branches that are used in the algo.