### PR TITLE
- Changes on the PileUp SF configuration to allows to create weights …

### DIFF
--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -269,6 +269,7 @@ file: GluGluToHHTo2B2Tau_node_SM_correctedcfg.root
 
 [Data_SingleElectron]
 apply_common_weights: false
+isData: true
 merged_output: SingleElectron_2017.root
 file: SingleElectron_Run2017B-31Mar2018-v1.root
 file: SingleElectron_Run2017C-31Mar2018-v1.root
@@ -278,6 +279,7 @@ file: SingleElectron_Run2017F-31Mar2018-v1.root
 
 [Data_SingleMuon]
 apply_common_weights: false
+isData: true
 merged_output: SingleMuon_2017.root
 file: SingleMuon_Run2017B-31Mar2018-v1.root
 file: SingleMuon_Run2017C-31Mar2018-v1.root
@@ -287,6 +289,7 @@ file: SingleMuon_Run2017F-31Mar2018-v1.root SingleMuon_Run2017F-31Mar2018-v1_par
 
 [Data_Tau]
 apply_common_weights: false
+isData: true
 merged_output: Tau_2017.root
 file: Tau_Run2017B-31Mar2018-v1.root
 file: Tau_Run2017C-31Mar2018-v1.root

--- a/Instruments/include/SkimmerConfig.h
+++ b/Instruments/include/SkimmerConfig.h
@@ -87,6 +87,7 @@ struct SkimJob {
     std::string merged_output;
     std::vector<FileDescriptor> files;
     bool apply_common_weights{true};
+    bool isData{false};
     mc_corrections::WeightingMode weights;
 
     bool ProduceMergedOutput() const { return merged_output.size(); }

--- a/Instruments/include/SkimmerConfigEntryReader.h
+++ b/Instruments/include/SkimmerConfigEntryReader.h
@@ -71,6 +71,7 @@ public:
         CheckReadParamCounts("merged_output", 1, Condition::less_equal);
         CheckReadParamCounts("apply_common_weights", 1, Condition::less_equal);
         CheckReadParamCounts("weights", 1, Condition::less_equal);
+        CheckReadParamCounts("isData", 1, Condition::less_equal);
 
         const size_t n_files = GetReadParamCounts("file");
         const size_t n_files_ex = GetReadParamCounts("file_ex");
@@ -92,6 +93,7 @@ public:
         ParseFileDescriptor(param_name, param_value);
         ParseEntry("apply_common_weights", current.apply_common_weights);
         ParseEntryList("weights", current.weights);
+        ParseEntry("isData", current.isData);
     }
 
 private:

--- a/Instruments/source/TupleSkimmer.cxx
+++ b/Instruments/source/TupleSkimmer.cxx
@@ -272,13 +272,22 @@ private:
                     using FullEventIdSet = std::set<FullEventId>;
 
                     FullEventIdSet processed_events;
-
                     for(size_t n = 0; n < desc_iter->inputs.size(); ++n) {
                         auto file = inputFiles.at(n);
                         std::cout << "\t\t" << desc_iter->inputs.at(n) << ":" << treeName << std::endl;
 
                         if(!desc_iter->first_input_is_ref && (!desc_iter->input_is_partial.size() || desc_iter->input_is_partial.at(n) == false))
                             processed_events.clear();
+                        if((n == 0 || !desc_iter->first_input_is_ref) && weighting_mode.count(mc_corrections::WeightType::PileUp)
+                                && setup.period == Period::Run2017 ) {
+                            auto pile_up_weight = eventWeights_HH->GetProviderT<mc_corrections::PileUpWeightEx>(mc_corrections::WeightType::PileUp);
+
+                            auto dataset_name_raw = RemoveFileExtension(desc_iter->inputs.at(n));
+                            std::ostringstream ss_dataset_name;
+                            std::string dataset_name = ss_dataset_name.str();
+                            
+                            pile_up_weight->SetActiveDataset(dataset_name);
+                        }
 
                         std::shared_ptr<EventTuple> tuple;
                         try {
@@ -306,6 +315,7 @@ private:
                             event_ptr->weight_xs_withTopPt = weight_xs_withTopPt;
                             event_ptr->file_desc_id = desc_id;
                             event_ptr->split_id = 0;
+                            event_ptr->isData = job.isData;
                             if(split_distr) {
                                 const EventIdentifier event_id(event);
                                 event_ptr->split_id = event_id == prev_event_id
@@ -389,19 +399,35 @@ private:
         }
     }
 
+
+    ntuple::ProdSummary GetSummaryWithWeights(const FileDescriptor& desc, const std::shared_ptr<TFile>& file,
+                                              size_t file_index)
+    {
+        if(weighting_mode.count(mc_corrections::WeightType::PileUp) && setup.period == Period::Run2017){
+            auto pile_up_weight = eventWeights_HH->GetProviderT<mc_corrections::PileUpWeightEx>(
+                                                                mc_corrections::WeightType::PileUp);
+            auto dataset_name_raw = RemoveFileExtension(desc.inputs.at(file_index));
+            std::ostringstream ss_dataset_name;
+            std::string dataset_name = ss_dataset_name.str();
+
+            pile_up_weight->SetActiveDataset(dataset_name);
+        }
+        return eventWeights_HH->GetSummaryWithWeights(file, weighting_mode);
+    }
+
     ProdSummary GetCombinedSummary(const FileDescriptor& desc, const std::vector<std::shared_ptr<TFile>>& input_files,
                                    double& weight_xs, double& weight_xs_withTopPt)
     {
         if(!input_files.size())
             throw exception("Input files list is empty.");
         auto file_iter = input_files.begin();
-        auto summary = eventWeights_HH->GetSummaryWithWeights(*file_iter++, weighting_mode);
+        auto summary = GetSummaryWithWeights(desc, *file_iter++, 0);
         if(!desc.first_input_is_ref) {
             unsigned n=1;
             for(; file_iter != input_files.end(); ++file_iter, ++n) {
                 if (desc.input_is_partial.size() && desc.input_is_partial.at(n) == true)
                     continue;
-                auto other_summary = eventWeights_HH->GetSummaryWithWeights(*file_iter, weighting_mode);
+                auto other_summary = GetSummaryWithWeights(desc, *file_iter, n);
                 ntuple::MergeProdSummaries(summary, other_summary);
             }
         }
@@ -430,7 +456,7 @@ private:
     bool ProcessEvent(Event& event, const std::shared_ptr<Event>& prev_event, ntuple::StorageMode& storage_mode,
                       bool prev_event_stored)
     {
-//        using EventPart = ntuple::StorageMode::EventPart;
+        // using EventPart = ntuple::StorageMode::EventPart;
         using WeightType = mc_corrections::WeightType;
         using WeightingMode = mc_corrections::WeightingMode;
 
@@ -446,12 +472,13 @@ private:
             event.storageMode = static_cast<UInt_t>(storage_mode.Mode());
         }
 
-
         auto event_metFilters = ntuple::MetFilters(full_event.metFilters);
-        if (!event_metFilters.Pass(Filter::PrimaryVertex) || !event_metFilters.Pass(Filter::BeamHalo) ||
-                !event_metFilters.Pass(Filter::HBHE_noise) || !event_metFilters.Pass(Filter::HBHEiso_noise) ||
-                !event_metFilters.Pass(Filter::ECAL_TP) || !event_metFilters.Pass(Filter::badMuon) ||
-                !event_metFilters.Pass(Filter::badChargedHadron) ) return false;
+        if (!event_metFilters.Pass(Filter::PrimaryVertex)  || !event_metFilters.Pass(Filter::BeamHalo) ||
+            !event_metFilters.Pass(Filter::HBHE_noise)  || !event_metFilters.Pass(Filter::HBHEiso_noise) ||
+            !event_metFilters.Pass(Filter::ECAL_TP) || !event_metFilters.Pass(Filter::badMuon) ||
+            !event_metFilters.Pass(Filter::badChargedHadron)) return false;
+
+        if(event.isData && !event_metFilters.Pass(Filter::ee_badSC_noise)) return false;
 
         if(!setup.energy_scales.count(es) || full_event.extraelec_veto || full_event.extramuon_veto) return false;
 
@@ -477,8 +504,7 @@ private:
                 pass_mass_cut = pass_mass_cut || setup.massWindowParams.at(SelectionCut::mhMET)
                         .IsInside((full_event.p4_1 + full_event.p4_2 + full_event.pfMET_p4).mass(),mbb);
 
-            if(!pass_mass_cut)
-                return false;
+            if(!pass_mass_cut) return false;
         }
 
         if (setup.apply_charge_cut && (full_event.q_1+full_event.q_2) != 0) return false;


### PR DESCRIPTION
- Changes on the PileUp SF configuration to allows to create weights for groups of samples
- Remove from the list of the MetFilters ecalBadCalib. 
- Add Parameter in the config isData
- Add MetFilter ee_badSC_noise only for data