### PR TITLE
Include genEventWeight and other fixes

### DIFF
--- a/Analysis/config/2017/histograms.cfg
+++ b/Analysis/config/2017/histograms.cfg
@@ -56,7 +56,8 @@ m_tt_vis/muMu/*/mh_lowMET_medHT: x_bins="75 85 90 95 100 110 125 140 156" x_titl
 m_tt_vis/muMu/*/mh_lowMET_highHT: x_bins="75 85 90 95 100 110 125 140 156" x_title="M_{vis}(GeV)" \
             y_title="dN/dm (1/GeV)" max_y_sf=400.0 log_y=true
 
-pt_H_tt: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+#pt_H_tt: x_bins="0 20 40 60 80 100 125 150 175 200 250 300" x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
+pt_H_tt: x_range=0:300/20 x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=1.4
 pt_H_tt/muMu: x_bins="0 10 20 30 40 50 60 70 80 90 100 120 140 160 180 200 225 250 275 300 325 350 375 400 450 500" \
               x_title="P_{T}(GeV)" y_title="dN/dm (1/GeV)" max_y_sf=400.0 log_y=true y_min=1e-3
 pt_H_tt/muMu/2jets2btag: x_bins="0 10 20 30 40 50 60 70 80 90 100 120 140 160 180 200 225 250 300 350 500" \

--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -5,8 +5,8 @@ energy_scales: all
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF 2j1b+B 2j1b+B_noVBF 2j0b 2j1b 2j2b+ 2j0Lb 2j1Lb 2j2Lb 2j1bR 2j2b+R
 categories: 2j
-sub_categories: NoCuts
-#sub_categories: mh
+#sub_categories: NoCuts
+sub_categories: mh
 regions: OS_Isolated OS_AntiIsolated SS_Isolated SS_AntiIsolated SS_LooseIsolated
 limit_setup: MVA_res mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF  m_ttbb_kinfit:4j1b+_VBF
 limit_setup: MVA_nonres mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF MT2:4j1b+_VBF
@@ -19,7 +19,7 @@ massWindowParams: mh 116.0 35.0 111.0 45.0
 massWindowParams: mhVis 87.9563 41.8451 109.639 43.0346
 jet_ordering: DeepCSV
 #unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
-syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo
+#syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/TTTo2L2Nu
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/ 2jets1btagR/mh/OS_Isolated/Central/TT 2jets2btagR/mh/OS_Isolated/Central/TT 2jets/mh/OS_Isolated/Central/Data_Tau 2jets1btagR/mh/OS_Isolated/Central/Data_Tau 2jets2btagR/mh/OS_Isolated/Central/Data_Tau
 trigger: eTau HLT_Ele32_WPTight_Gsf_v HLT_Ele35_WPTight_Gsf_v HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v
@@ -29,13 +29,14 @@ trigger: tauTau HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v HLT_D
 
 [ANA_DESC full : common]
 #signals: GluGluSignal_Radion GluGluSignal_Graviton GluGluSignal_NonRes
-#signals: GluGluSignal_NonRes VBFSignal_NonRes
-#backgrounds: TTTo2L2Nu TTToSemiLeptonic TTToHadronic DY_nlo Wjets VV VH EWK ST QCD ttV ttVV ttH VVV SM_Higgs
-backgrounds: DY_nlo
-#data: Data_SingleElectron Data_SingleMuon Data_Tau
+signals: GluGluSignal_NonRes VBFSignal_NonRes
+backgrounds: TTTo2L2Nu TTToSemiLeptonic TTToHadronic DY_nlo Wjets VV VH EWK ST QCD ttV ttVV ttH VVV SM_Higgs
+#backgrounds: DY_nlo
+data: Data_SingleElectron Data_SingleMuon Data_Tau
 #data: Data_Tau
-#cmb_samples: other_bkg TT SM
-draw_sequence: DY_nlo
+cmb_samples: other_bkg TT SM
+#draw_sequence: DY_nlo
+draw_sequence: data DY_nlo TT Wjets QCD EWK ST SM VVV ttV ttVV VV
 #draw_sequence: data TT DY_nlo QCD Wjets other_bkg SM signals
 
 [ANA_DESC full_postfit : full]

--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -5,8 +5,8 @@ energy_scales: all
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF 2j1b+B 2j1b+B_noVBF 2j0b 2j1b 2j2b+ 2j0Lb 2j1Lb 2j2Lb 2j1bR 2j2b+R
 categories: 2j
-#sub_categories: NoCuts
-sub_categories: mh
+sub_categories: NoCuts
+#sub_categories: mh
 regions: OS_Isolated OS_AntiIsolated SS_Isolated SS_AntiIsolated SS_LooseIsolated
 limit_setup: MVA_res mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF  m_ttbb_kinfit:4j1b+_VBF
 limit_setup: MVA_nonres mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF MT2:4j1b+_VBF
@@ -19,7 +19,7 @@ massWindowParams: mh 116.0 35.0 111.0 45.0
 massWindowParams: mhVis 87.9563 41.8451 109.639 43.0346
 jet_ordering: DeepCSV
 #unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
-#syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo
+syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/TTTo2L2Nu
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/ 2jets1btagR/mh/OS_Isolated/Central/TT 2jets2btagR/mh/OS_Isolated/Central/TT 2jets/mh/OS_Isolated/Central/Data_Tau 2jets1btagR/mh/OS_Isolated/Central/Data_Tau 2jets2btagR/mh/OS_Isolated/Central/Data_Tau
 trigger: eTau HLT_Ele32_WPTight_Gsf_v HLT_Ele35_WPTight_Gsf_v HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v
@@ -29,14 +29,14 @@ trigger: tauTau HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v HLT_D
 
 [ANA_DESC full : common]
 #signals: GluGluSignal_Radion GluGluSignal_Graviton GluGluSignal_NonRes
-signals: GluGluSignal_NonRes VBFSignal_NonRes
-backgrounds: TTTo2L2Nu TTToSemiLeptonic TTToHadronic DY_nlo Wjets VV VH EWK ST QCD ttV ttVV ttH VVV SM_Higgs
-#backgrounds: DY_nlo
-data: Data_SingleElectron Data_SingleMuon Data_Tau
+#signals: GluGluSignal_NonRes VBFSignal_NonRes
+#backgrounds: TTTo2L2Nu TTToSemiLeptonic TTToHadronic DY_nlo Wjets VV VH EWK ST QCD ttV ttVV ttH VVV SM_Higgs
+backgrounds: DY_nlo
+#data: Data_SingleElectron Data_SingleMuon Data_Tau
 #data: Data_Tau
-cmb_samples: other_bkg TT SM
-#draw_sequence: data DY_nlo TT Wjets QCD EWK ST SM VVV ttV ttVV VV
-draw_sequence: data TT DY_nlo QCD Wjets other_bkg SM signals
+#cmb_samples: other_bkg TT SM
+draw_sequence: DY_nlo
+#draw_sequence: data TT DY_nlo QCD Wjets other_bkg SM signals
 
 [ANA_DESC full_postfit : full]
 backgrounds: TotalBkg

--- a/Analysis/include/NonResModel.h
+++ b/Analysis/include/NonResModel.h
@@ -70,7 +70,8 @@ private:
 
 public:
     NonResModel(Period period, const SampleDescriptor& sample, std::shared_ptr<TFile> file)
-        : weighting_mode({WeightType::PileUp, WeightType::BSM_to_SM}),
+        : weighting_mode({WeightType::PileUp, WeightType::BSM_to_SM, WeightType::GenEventWeight}),
+        // : weighting_mode({WeightType::PileUp, WeightType::BSM_to_SM}),
           weights(period, JetOrdering::NoOrdering, DiscriminatorWP::Medium, false, weighting_mode),
           eft_weights(weights.GetProviderT<NonResHH_EFT::WeightProvider>(WeightType::BSM_to_SM))
     {

--- a/Analysis/include/NonResModel.h
+++ b/Analysis/include/NonResModel.h
@@ -71,7 +71,6 @@ private:
 public:
     NonResModel(Period period, const SampleDescriptor& sample, std::shared_ptr<TFile> file)
         : weighting_mode({WeightType::PileUp, WeightType::BSM_to_SM, WeightType::GenEventWeight}),
-        // : weighting_mode({WeightType::PileUp, WeightType::BSM_to_SM}),
           weights(period, JetOrdering::NoOrdering, DiscriminatorWP::Medium, false, weighting_mode),
           eft_weights(weights.GetProviderT<NonResHH_EFT::WeightProvider>(WeightType::BSM_to_SM))
     {

--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -19,7 +19,7 @@ keep_genJets: true
 keep_genParticles: true
 
 [SETUP mh_setup : setup_base]
-channels: eTau
+channels: eTau muTau tauTau
 energy_scales: all
 apply_mass_cut: true
 

--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -3,6 +3,7 @@ period: Run2017
 jet_ordering: DeepCSV
 btag_wp: Medium
 common_weights: PileUp BTag LeptonTrigIdIso GenEventWeight
+#common_weights: PileUp BTag LeptonTrigIdIso 
 n_splits: 120
 split_seed: 1234567
 massWindowParams: mh 116.0 35.0 111.0 45.0
@@ -19,7 +20,7 @@ keep_genJets: true
 keep_genParticles: true
 
 [SETUP mh_setup : setup_base]
-channels: eTau 
+channels: eTau
 energy_scales: all
 apply_mass_cut: true
 

--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -2,7 +2,7 @@
 period: Run2017
 jet_ordering: DeepCSV
 btag_wp: Medium
-common_weights: PileUp BTag LeptonTrigIdIso
+common_weights: PileUp BTag LeptonTrigIdIso GenEventWeight
 n_splits: 120
 split_seed: 1234567
 massWindowParams: mh 116.0 35.0 111.0 45.0
@@ -19,7 +19,7 @@ keep_genJets: true
 keep_genParticles: true
 
 [SETUP mh_setup : setup_base]
-channels: eTau muTau tauTau
+channels: eTau 
 energy_scales: all
 apply_mass_cut: true
 

--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -3,7 +3,6 @@ period: Run2017
 jet_ordering: DeepCSV
 btag_wp: Medium
 common_weights: PileUp BTag LeptonTrigIdIso GenEventWeight
-#common_weights: PileUp BTag LeptonTrigIdIso 
 n_splits: 120
 split_seed: 1234567
 massWindowParams: mh 116.0 35.0 111.0 45.0
@@ -15,7 +14,7 @@ energy_scales: Central
 apply_mass_cut: false
 apply_bb_cut: true
 apply_charge_cut: true
-tau_id_cuts: byMediumIsolationMVArun2v1DBoldDMwLT
+tau_id_cuts: byMediumIsolationMVArun2017v2DBoldDMwLT2017
 keep_genJets: true
 keep_genParticles: true
 
@@ -30,7 +29,7 @@ energy_scales: Central
 apply_mass_cut: false
 apply_bb_cut: true
 apply_charge_cut: true
-tau_id_cuts: byMediumIsolationMVArun2v1DBoldDMwLT
+tau_id_cuts: byMediumIsolationMVArun2017v2DBoldDMwLT2017
 keep_genJets: false
 keep_genParticles: false
 

--- a/McCorrections/include/EventWeights_HH.h
+++ b/McCorrections/include/EventWeights_HH.h
@@ -49,7 +49,7 @@ public:
                                               const WeightingMode& weighting_mode) const
     {
         static const WeightingMode shape_weights = { WeightType::PileUp, WeightType::BSM_to_SM, WeightType::DY,
-                                                   WeightType::TTbar, WeightType::Wjets};
+                                                   WeightType::TTbar, WeightType::Wjets, WeightType::GenEventWeight };
         static const WeightingMode shape_weights_withTopPt = shape_weights | WeightingMode({WeightType::TopPt});
 
         auto summary_tuple = ntuple::CreateSummaryTuple("summary", file.get(), true, ntuple::TreeState::Full);


### PR DESCRIPTION
- Analysis/config/2017/histograms.cfg: Change the binning for the pt_H_tt histogram
- Analysis/config/2017/sources.cfg: Add draw_sequence for sync
- Analysis/include/NonResModel.h: Add to weighting_mode new WeightType: GenEventWeight
- Instruments/config/2017/Skimmer.cfg: Update tau_id_cuts for 2017.  Also added to common_weights: GenEventWeight
-  McCorrections/include/EventWeights_HH.h: Add to shape_weights new WeightType: GenEventWeight
