### PR TITLE
Combination of synctuple from different subcategories

### DIFF
--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -19,7 +19,7 @@ plot_page_opt: internal_plot
 massWindowParams: mh 116.0 35.0 111.0 45.0
 massWindowParams: mhVis 87.9563 41.8451 109.639 43.0346
 jet_ordering: DeepCSV
-unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
+#unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
 syncDataIds: sync_DY_nlo:2j/mh/OS_Isolated/Central/DY_nlo_SF_.*
 #syncDataIds: 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_40Pt #2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_100Pt
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo_SF

--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -136,14 +136,6 @@ norm_sf_file: hh-bbtautau/McCorrections/data/DY_Scale_factors_NbjetBin_ptfit_LO_
 file_path: DYJets_nlo.root
 sample_order: NLO
 
-#[DY_nlo]
-#file_path: DYJets_nlo.root
-#cross_section: 6225.42
-#sample_type: MC
-#title: DY #rightarrow ll + jets
-#color: kYellow
-#datacard_name: DY
-
 [DY_lo : DY_MC]
 file_path: DYJetsToLL_M-50.root
 sample_order: LO
@@ -268,7 +260,7 @@ draw_ex: M600 kBlue
 draw_sf: 0.01
 channels: eTau muTau tauTau
 sample_type: MC
-#datacard_name: ggRadion_hh_ttbb_M{M}
+datacard_name: ggRadion_hh_ttbb_M{M}
 postfit_name: ggRadion_hh_ttbb
 
 [GluGluSignal_Graviton]
@@ -280,7 +272,7 @@ draw_ex: M250 kGreen
 draw_ex: M600 kBlue
 channels: eTau muTau tauTau
 sample_type: MC
-#datacard_name: ggGraviton_hh_ttbb_M{M}
+datacard_name: ggGraviton_hh_ttbb_M{M}
 
 [GluGluSignal_NonRes]
 file_path: ggHH_SM.root
@@ -295,7 +287,7 @@ draw_sf: 20
 title: {factor}x SM gg#rightarrowHH#rightarrowbb#tau#tau
 draw_ex: kl1 kBlack
 channels: eTau muTau tauTau
-#datacard_name: ggh_hh_ttbb_kl{kl}
+datacard_name: ggh_hh_ttbb_kl{kl}
 postfit_name: ggh_hh_ttbb
 
 [VBFSignal_Radion]
@@ -320,7 +312,7 @@ draw_ex: M250 kGreen
 draw_ex: M600 kBlue
 channels: eTau muTau tauTau
 sample_type: MC
-#datacard_name: VBFGraviton_hh_ttbb_M{M}
+datacard_name: VBFGraviton_hh_ttbb_M{M}
 
 [VBFSignal_NonRes]
 name_suffix: VBFHH-CV_{CV}_C2V_{C2V}_C3_{C3}
@@ -339,7 +331,7 @@ draw_sf: 20
 draw_ex: VBFHH-CV_1_C2V_1_C3_0 kBlue+1
 channels: eTau muTau tauTau
 sample_type: MC
-#datacard_name: VBFHH_hh_ttbb_M{M}
+datacard_name: VBFHH_hh_ttbb_M{M}
 postfit_name: VBFHH_hh_ttbb
 
 [Data_SingleElectron]
@@ -354,7 +346,7 @@ file_path: SingleMuon_2017.root
 title: Data
 channels: muTau muMu
 sample_type: Data
-#datacard_name: data_obs
+datacard_name: data_obs
 
 [Data_Tau]
 file_path: Tau_2017.root
@@ -375,7 +367,7 @@ datacard_name: TotalBkg
 
 [SAMPLE_CMB other_bkg]
 #sample_descriptors: VV Wjets ST EWK
-sample_descriptors: EWK ST SM_Higgs VVV ttV ttVV VV
+sample_descriptors: EWK ST VVV ttV ttVV VV
 color: kCyan+2
 title: Other backgrounds
 
@@ -388,7 +380,7 @@ color: kYellow
 [SAMPLE_CMB SM]
 sample_descriptors: VH ttH SM_Higgs
 color: kPink-6
-title: SM
+title: SM Higgs
 datacard_name: H
 
 #[SAMPLE_CMB Signal_NonRes]

--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -6,8 +6,6 @@ energy_scales: Central
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF 2j1b+B 2j1b+B_noVBF 2j0b 2j1b 2j2b+ 2j0Lb 2j1Lb 2j2Lb 2j1bR 2j2b+R
 categories: 2j
 sub_categories: mh NoCuts
-#sub_categories: NoCuts
-#sub_categories: notmh
 regions: OS_Isolated OS_AntiIsolated SS_Isolated SS_AntiIsolated SS_LooseIsolated
 limit_setup: MVA_res mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF  m_ttbb_kinfit:4j1b+_VBF
 limit_setup: MVA_nonres mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF MT2:4j1b+_VBF
@@ -20,11 +18,7 @@ massWindowParams: mh 116.0 35.0 111.0 45.0
 massWindowParams: mhVis 87.9563 41.8451 109.639 43.0346
 jet_ordering: DeepCSV
 #unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
-syncDataIds: sync_DY_nlo:2j/mh/OS_Isolated/Central/DY_nlo_SF_.*
-#syncDataIds: 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_40Pt #2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_100Pt
-#syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo_SF
-#syncDataIds: 2j/NoCuts/OS_Isolated/Central/TTTo2L2Nu
-#syncDataIds: 2j/NoCuts/OS_Isolated/Central/ 2jets1btagR/mh/OS_Isolated/Central/TT 2jets2btagR/mh/OS_Isolated/Central/TT 2jets/mh/OS_Isolated/Central/Data_Tau 2jets1btagR/mh/OS_Isolated/Central/Data_Tau 2jets2btagR/mh/OS_Isolated/Central/Data_Tau
+#syncDataIds: sync_DY_nlo:2j/mh/OS_Isolated/Central/DY_nlo_SF_.*
 trigger: eTau HLT_Ele32_WPTight_Gsf_v HLT_Ele35_WPTight_Gsf_v HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v
 trigger: muTau HLT_IsoMu24_v HLT_IsoMu27_v HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v
 trigger: muMu HLT_IsoMu24_v HLT_IsoMu27_v
@@ -95,7 +89,7 @@ sample_type: DY
 points: b 0 0 0 0 1 1 1 1 2 2 2 2
 points: Pt 0 20 40 100 0 20 40 100 0 20 40 100
 name_suffix: {b}b_{Pt}Pt
-#datacard_name: DY_{b}b_{Pt}JPt
+datacard_name: DY_{b}b_{Pt}JPt
 draw_ex: 0b_0Pt kYellow
 draw_ex: 0b_20Pt kOrange
 draw_ex: 0b_40Pt kRed
@@ -374,7 +368,7 @@ title: Other backgrounds
 [SAMPLE_CMB DY_nlo_cmb]
 sample_descriptors: DY_nlo_SF
 title: DY #rightarrow ll + jets
-datacard_name: DY
+#datacard_name: DY
 color: kYellow
 
 [SAMPLE_CMB SM]

--- a/Analysis/config/2017/sources.cfg
+++ b/Analysis/config/2017/sources.cfg
@@ -1,12 +1,13 @@
 [ANA_DESC common]
 int_lumi: 41529.343
 period: Run2017
-energy_scales: all
+energy_scales: Central
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF
 #categories: 2j 2j0bR_noVBF 2j1bR_noVBF 2j2b+R_noVBF 2j2Lb+B_noVBF 4j1b+_VBF 2j1b+B 2j1b+B_noVBF 2j0b 2j1b 2j2b+ 2j0Lb 2j1Lb 2j2Lb 2j1bR 2j2b+R
-categories: 2j 1j 0j
-sub_categories: NoCuts
-#sub_categories: mh
+categories: 2j
+sub_categories: mh NoCuts
+#sub_categories: NoCuts
+#sub_categories: notmh
 regions: OS_Isolated OS_AntiIsolated SS_Isolated SS_AntiIsolated SS_LooseIsolated
 limit_setup: MVA_res mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF  m_ttbb_kinfit:4j1b+_VBF
 limit_setup: MVA_nonres mva_score:2j1bR_noVBF,2j2b+R_noVBF,2j2Lb+B_noVBF MT2:4j1b+_VBF
@@ -18,8 +19,10 @@ plot_page_opt: internal_plot
 massWindowParams: mh 116.0 35.0 111.0 45.0
 massWindowParams: mhVis 87.9563 41.8451 109.639 43.0346
 jet_ordering: DeepCSV
-#unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
-#syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo
+unc_cfg: hh-bbtautau/Analysis/config/2017/prefit_unc.cfg
+syncDataIds: sync_DY_nlo:2j/mh/OS_Isolated/Central/DY_nlo_SF_.*
+#syncDataIds: 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_0b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_40Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_1b_100Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_0Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_20Pt 2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_40Pt #2j/mh/OS_Isolated/Central/DY_nlo_SF_2b_100Pt
+#syncDataIds: 2j/NoCuts/OS_Isolated/Central/DY_nlo_SF
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/TTTo2L2Nu
 #syncDataIds: 2j/NoCuts/OS_Isolated/Central/ 2jets1btagR/mh/OS_Isolated/Central/TT 2jets2btagR/mh/OS_Isolated/Central/TT 2jets/mh/OS_Isolated/Central/Data_Tau 2jets1btagR/mh/OS_Isolated/Central/Data_Tau 2jets2btagR/mh/OS_Isolated/Central/Data_Tau
 trigger: eTau HLT_Ele32_WPTight_Gsf_v HLT_Ele35_WPTight_Gsf_v HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v
@@ -35,10 +38,10 @@ backgrounds: TTTo2L2Nu TTToSemiLeptonic TTToHadronic DY_nlo_SF Wjets VV VH EWK S
 data: Data_SingleElectron Data_SingleMuon Data_Tau
 #data: Data_Tau
 #cmb_samples: other_bkg TT SM
-cmb_samples: TT SM
+cmb_samples: TT SM DY_nlo_cmb
 #draw_sequence: DY_nlo
-draw_sequence: data DY_nlo_SF TT Wjets QCD EWK ST SM VVV ttV ttVV VV
-#draw_sequence: data TT DY_nlo QCD Wjets other_bkg SM signals
+#draw_sequence: data DY_nlo_cmb TT Wjets QCD other_bkg
+draw_sequence: data DY_nlo_cmb TT QCD EWK ST SM ttV ttVV VVV VV
 
 [ANA_DESC full_postfit : full]
 backgrounds: TotalBkg
@@ -92,7 +95,7 @@ sample_type: DY
 points: b 0 0 0 0 1 1 1 1 2 2 2 2
 points: Pt 0 20 40 100 0 20 40 100 0 20 40 100
 name_suffix: {b}b_{Pt}Pt
-datacard_name: DY_{b}b_{Pt}JPt
+#datacard_name: DY_{b}b_{Pt}JPt
 draw_ex: 0b_0Pt kYellow
 draw_ex: 0b_20Pt kOrange
 draw_ex: 0b_40Pt kRed
@@ -132,6 +135,14 @@ norm_sf_file: hh-bbtautau/McCorrections/data/DY_Scale_factors_NbjetBin_ptfit_LO_
 [DY_nlo : DY_MC]
 file_path: DYJets_nlo.root
 sample_order: NLO
+
+#[DY_nlo]
+#file_path: DYJets_nlo.root
+#cross_section: 6225.42
+#sample_type: MC
+#title: DY #rightarrow ll + jets
+#color: kYellow
+#datacard_name: DY
 
 [DY_lo : DY_MC]
 file_path: DYJetsToLL_M-50.root
@@ -180,7 +191,7 @@ sample_type: TT
 
 [SAMPLE_CMB TT]
 sample_descriptors: TTTo2L2Nu TTToSemiLeptonic TTToHadronic
-color: kRed-5
+color: kRed-3
 datacard_name: TT
 
 [ST]
@@ -257,7 +268,7 @@ draw_ex: M600 kBlue
 draw_sf: 0.01
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: ggRadion_hh_ttbb_M{M}
+#datacard_name: ggRadion_hh_ttbb_M{M}
 postfit_name: ggRadion_hh_ttbb
 
 [GluGluSignal_Graviton]
@@ -269,7 +280,7 @@ draw_ex: M250 kGreen
 draw_ex: M600 kBlue
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: ggGraviton_hh_ttbb_M{M}
+#datacard_name: ggGraviton_hh_ttbb_M{M}
 
 [GluGluSignal_NonRes]
 file_path: ggHH_SM.root
@@ -284,7 +295,7 @@ draw_sf: 20
 title: {factor}x SM gg#rightarrowHH#rightarrowbb#tau#tau
 draw_ex: kl1 kBlack
 channels: eTau muTau tauTau
-datacard_name: ggh_hh_ttbb_kl{kl}
+#datacard_name: ggh_hh_ttbb_kl{kl}
 postfit_name: ggh_hh_ttbb
 
 [VBFSignal_Radion]
@@ -309,7 +320,7 @@ draw_ex: M250 kGreen
 draw_ex: M600 kBlue
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: VBFGraviton_hh_ttbb_M{M}
+#datacard_name: VBFGraviton_hh_ttbb_M{M}
 
 [VBFSignal_NonRes]
 name_suffix: VBFHH-CV_{CV}_C2V_{C2V}_C3_{C3}
@@ -328,7 +339,7 @@ draw_sf: 20
 draw_ex: VBFHH-CV_1_C2V_1_C3_0 kBlue+1
 channels: eTau muTau tauTau
 sample_type: MC
-datacard_name: VBFHH_hh_ttbb_M{M}
+#datacard_name: VBFHH_hh_ttbb_M{M}
 postfit_name: VBFHH_hh_ttbb
 
 [Data_SingleElectron]
@@ -343,7 +354,7 @@ file_path: SingleMuon_2017.root
 title: Data
 channels: muTau muMu
 sample_type: Data
-datacard_name: data_obs
+#datacard_name: data_obs
 
 [Data_Tau]
 file_path: Tau_2017.root
@@ -364,13 +375,20 @@ datacard_name: TotalBkg
 
 [SAMPLE_CMB other_bkg]
 #sample_descriptors: VV Wjets ST EWK
-sample_descriptors: VV VVV ST EWK ttV ttVV
+sample_descriptors: EWK ST SM_Higgs VVV ttV ttVV VV
 color: kCyan+2
 title: Other backgrounds
+
+[SAMPLE_CMB DY_nlo_cmb]
+sample_descriptors: DY_nlo_SF
+title: DY #rightarrow ll + jets
+datacard_name: DY
+color: kYellow
 
 [SAMPLE_CMB SM]
 sample_descriptors: VH ttH SM_Higgs
 color: kPink-6
+title: SM
 datacard_name: H
 
 #[SAMPLE_CMB Signal_NonRes]

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -22,9 +22,7 @@ struct SyncDescriptor {
     std::shared_ptr<htt_sync::SyncTuple> sync_tree;
     std::shared_ptr<boost::regex> regex_pattern;
 
-    SyncDescriptor(std::shared_ptr<htt_sync::SyncTuple> _sync_tree,
-                   std::shared_ptr<boost::regex> _regex_pattern) :
-    sync_tree(_sync_tree), regex_pattern(_regex_pattern) {}
+    SyncDescriptor(const std::string& desc_str, std::shared_ptr<TFile> outputFile_sync);
 
 };
 
@@ -56,7 +54,6 @@ protected:
     bbtautau::AnaTupleWriter anaTupleWriter;
     mva_study::MvaReader mva_reader;
     std::shared_ptr<TFile> outputFile_sync;
-    // std::map<EventAnalyzerDataId, std::shared_ptr<htt_sync::SyncTuple>> syncTuple_map;
     std::vector<SyncDescriptor> sync_descriptors;
     std::map<std::string,std::shared_ptr<DYModel>> dymod;
     std::shared_ptr<NonResModel> nonResModel;

--- a/Analysis/include/BaseEventAnalyzer.h
+++ b/Analysis/include/BaseEventAnalyzer.h
@@ -8,6 +8,7 @@ This file is part of https://github.com/hh-italian-group/hh-bbtautau. */
 #include "MvaReader.h"
 #include "NonResModel.h"
 #include "SyncTupleHTT.h"
+#include <boost/regex.hpp>
 
 namespace analysis {
 
@@ -15,6 +16,16 @@ struct AnalyzerArguments : CoreAnalyzerArguments {
     REQ_ARG(std::string, input);
     REQ_ARG(std::string, output);
     OPT_ARG(std::string, output_sync,"sync.root");
+};
+
+struct SyncDescriptor {
+    std::shared_ptr<htt_sync::SyncTuple> sync_tree;
+    std::shared_ptr<boost::regex> regex_pattern;
+
+    SyncDescriptor(std::shared_ptr<htt_sync::SyncTuple> _sync_tree,
+                   std::shared_ptr<boost::regex> _regex_pattern) :
+    sync_tree(_sync_tree), regex_pattern(_regex_pattern) {}
+
 };
 
 class BaseEventAnalyzer : public EventAnalyzerCore {
@@ -45,7 +56,8 @@ protected:
     bbtautau::AnaTupleWriter anaTupleWriter;
     mva_study::MvaReader mva_reader;
     std::shared_ptr<TFile> outputFile_sync;
-    std::map<EventAnalyzerDataId, std::shared_ptr<htt_sync::SyncTuple>> syncTuple_map;
+    // std::map<EventAnalyzerDataId, std::shared_ptr<htt_sync::SyncTuple>> syncTuple_map;
+    std::vector<SyncDescriptor> sync_descriptors;
     std::map<std::string,std::shared_ptr<DYModel>> dymod;
     std::shared_ptr<NonResModel> nonResModel;
     const std::vector<std::string> trigger_patterns;

--- a/Analysis/include/SampleDescriptor.h
+++ b/Analysis/include/SampleDescriptor.h
@@ -27,7 +27,7 @@ struct AnalyzerSetup {
     std::vector<std::string> draw_sequence;
     std::map<EventCategory, std::string> limit_categories;
     std::string mva_setup, hist_cfg;
-    std::vector<EventAnalyzerDataId> syncDataIds;
+    std::vector<std::string> syncDataIds;
     std::string plot_cfg, plot_page_opt, unc_cfg;
     JetOrdering jet_ordering;
     std::map<Channel, std::vector<std::string>> trigger;

--- a/Analysis/src/BaseEventAnalyzer.cpp
+++ b/Analysis/src/BaseEventAnalyzer.cpp
@@ -246,8 +246,7 @@ void BaseEventAnalyzer::ProcessDataSource(const SampleDescriptor& sample, const 
                                             / summary->totalShapeWeight * mva_weight_scale;
                         if(sample.sampleType == SampleType::MC) {
                             dataIds[anaDataId] = std::make_tuple(weight, mva_score);
-                        }
-                        else
+                        } else
                             ProcessSpecialEvent(sample, sample_wp, anaDataId, *event, weight,
                                                 summary->totalShapeWeight, dataIds);
                     }
@@ -257,7 +256,7 @@ void BaseEventAnalyzer::ProcessDataSource(const SampleDescriptor& sample, const 
 
         anaTupleWriter.AddEvent(*event, dataIds);
         for (size_t n = 0; n < sync_descriptors.size(); ++n) {
-            auto regex_pattern = sync_descriptors.at(n).regex_pattern;
+            const auto& regex_pattern = sync_descriptors.at(n).regex_pattern;
             for(auto& dataId : dataIds){
                 if(boost::regex_match(dataId.first.GetName(), *regex_pattern)){
                     htt_sync::FillSyncTuple(*event, *sync_descriptors.at(n).sync_tree, ana_setup.period);

--- a/Instruments/config/2017/Skimmer.cfg
+++ b/Instruments/config/2017/Skimmer.cfg
@@ -41,7 +41,7 @@ apply_bb_cut: false
 apply_charge_cut: false
 apply_kinfit: false
 keep_genJets: false
-keep_genParticles: false
+keep_genParticles: true
 
 [SETUP muMu : setup_base]
 energy_scales: Central


### PR DESCRIPTION
- Analysis/config/2017/sources.cfg: modified code to have correct sync for DY with different subcategories; Added combined descriptor for DY_nlo
- Analysis/include/BaseEventAnalyzer.h: added struct SyncDescriptor
- Analysis/include/SampleDescriptor.h: fixed syncDataIds
- Analysis/src/BaseEventAnalyzer.cpp: added the possibility to combined different subcategories in one syncTuple, especially for DY
- Instruments/config/2017/Skimmer.cfg: added keep genParticles = true for skimmed_HTT