### PR TITLE
Fixed EventCategory Parse/ToString + simplified AnaTuple.

### DIFF
--- a/Analysis/include/AnaTuple.h
+++ b/Analysis/include/AnaTuple.h
@@ -36,17 +36,37 @@ namespace analysis {
     VAR_LIST(float, name##_DeepFlavour, name##_DeepFlavour_CvsL, name##_DeepFlavour_CvsB, \
                     name##_HHbtag, name##_resolution) \
     VAR_LIST(int, name##_valid, name##_hadronFlavour) \
+    /**/
 
 #define FAT_JET_DATA(name) \
     P4_DATA(name) \
     VAR(float, name##_m_softDrop) \
     VAR(int, name##_valid) \
+    /**/
+
+#define UNC_VAR(name) \
+    VAR(float, unc_##name##_Up) \
+    VAR(float, unc_##name##_Down) \
+    /**/
+
+#define WVAR(name) \
+    VAR(float, weight_##name) \
+    UNC_VAR(name) \
+    /**/
+
+#define CREATE_UNC_VAR(r, _, name) UNC_VAR(name)
+#define UNC_VAR_LIST(_, ...) BOOST_PP_SEQ_FOR_EACH(CREATE_UNC_VAR, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+#define CREATE_WVAR(r, _, name) WVAR(name)
+#define WVAR_LIST(_, ...) BOOST_PP_SEQ_FOR_EACH(CREATE_WVAR, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
 
 #define ANA_EVENT_DATA() \
-    VAR(std::vector<size_t>, dataIds) /* hashed data ids. Each data id is combination of EventCategory / \
-                                         EventSubCategory / EventRegion / UncertaintySource / UncertaintyScale / \
-                                         Dataset */ \
-    VAR(std::vector<float>, all_weights) /* full event weight for each data id */ \
+    VAR(UInt_t, dataset) /* hashed dataset name */ \
+    VAR(UInt_t, event_region) /* hashed event region name */ \
+    VAR(Int_t, unc_source) /* uncertainty source */ \
+    VAR(Int_t, unc_scale) /* uncertainty scale */ \
+    VAR(float, weight) /* full event weight of the event (excluding category-dependent weights) */ \
     VAR_LIST(UInt_t, run, lumi) /* run ID and lumi ID */ \
     VAR(ULong64_t, evt)  /* event ID */ \
     VAR(int, channelId) /* Channel: 0 - eTau, 1 - muTau, 2 - tauTau, 3 - muMu */ \
@@ -89,20 +109,19 @@ namespace analysis {
     VAR_LIST(float, npv, HT_total, HT_otherjets, lhe_HT, n_jets, n_jets_eta24, n_jets_eta24_eta5, \
                     n_selected_gen_jets, n_selected_gen_bjets, genJets_nTotal, \
                     jets_nTotal_hadronFlavour_b, jets_nTotal_hadronFlavour_c) /* other global event quantities */ \
-    VAR_LIST(std::vector<float>, btag_weight_Loose, btag_weight_Medium, btag_weight_Tight, btag_weight_IterativeFit) \
+    WVAR_LIST(_, btag_Loose, btag_Medium, btag_Tight, btag_IterativeFit) \
              /* btag weights for various working points estimated by different algorithms and their unc variations */ \
-    VAR_LIST(std::vector<float>, \
-             unc_EleTriggerUnc, unc_MuonTriggerUnc, \
-             unc_TauTriggerUnc_DM0, unc_TauTriggerUnc_DM1, unc_TauTriggerUnc_DM10, unc_TauTriggerUnc_DM11, \
-             unc_TauVSjetSF_DM0, unc_TauVSjetSF_DM1, unc_TauVSjetSF_3prong, \
-             unc_TauVSjetSF_pt20to25, unc_TauVSjetSF_pt25to30, unc_TauVSjetSF_pt30to35, unc_TauVSjetSF_pt35to40, \
-             unc_TauVSjetSF_ptgt40, \
-             unc_TauVSeSF_barrel, unc_TauVSeSF_endcap, \
-             unc_TauVSmuSF_etaLt0p4, unc_TauVSmuSF_eta0p4to0p8, unc_TauVSmuSF_eta0p8to1p2, unc_TauVSmuSF_eta1p2to1p7, \
-             unc_TauVSmuSF_etaGt1p7, \
-             unc_EleIdIsoUnc, unc_MuonIdIsoUnc, \
-             unc_TopPt, unc_L1_prefiring, unc_PileUp, unc_PileUpJetId_eff, unc_PileUpJetId_mistag, \
-             unc_TauCustomSF_DM0, unc_TauCustomSF_DM1, unc_TauCustomSF_DM10, unc_TauCustomSF_DM11) \
+    UNC_VAR_LIST(_, \
+             EleTriggerUnc, MuonTriggerUnc, \
+             TauTriggerUnc_DM0, TauTriggerUnc_DM1, TauTriggerUnc_DM10, TauTriggerUnc_DM11, \
+             TauVSjetSF_DM0, TauVSjetSF_DM1, TauVSjetSF_3prong, \
+             TauVSjetSF_pt20to25, TauVSjetSF_pt25to30, TauVSjetSF_pt30to35, TauVSjetSF_pt35to40, TauVSjetSF_ptgt40, \
+             TauVSeSF_barrel, TauVSeSF_endcap, \
+             TauVSmuSF_etaLt0p4, TauVSmuSF_eta0p4to0p8, TauVSmuSF_eta0p8to1p2, TauVSmuSF_eta1p2to1p7, \
+             TauVSmuSF_etaGt1p7, \
+             EleIdIsoUnc, MuonIdIsoUnc, \
+             TopPt, L1_prefiring, PileUp, PileUpJetId_eff, PileUpJetId_mistag, \
+             TauCustomSF_DM0, TauCustomSF_DM1, TauCustomSF_DM10, TauCustomSF_DM11) \
              /* effects of various uncertainty sources on the event weight */ \
     /**/
 
@@ -122,10 +141,18 @@ INITIALIZE_TREE(bbtautau, AnaTuple, ANA_EVENT_DATA)
 #undef FAT_JET_DATA
 #undef P4_DATA
 #undef P4_DATA_EX
+#undef UNC_VAR
+#undef CREATE_UNC_VAR
+#undef UNC_VAR_LIST
+#undef WVAR
+#undef CREATE_WVAR
+#undef WVAR_LIST
 
 #define ANA_AUX_DATA() \
-    VAR(std::vector<size_t>, dataIds) /* EventAnalyzerDataId code */ \
-    VAR(std::vector<std::string>, dataId_names) /* EventAnalyzerDataId name */ \
+    VAR(std::vector<unsigned>, dataset_hashes) /* hash code for each dataset stored in AnaTuple */ \
+    VAR(std::vector<std::string>, dataset_names) /* name of each datasetd stored in AnaTuple */ \
+    VAR(std::vector<unsigned>, region_hashes) /* hash code for each event region stored in AnaTuple */ \
+    VAR(std::vector<std::string>, region_names) /* name of each datasetd stored in AnaTuple */ \
     /**/
 
 #define VAR(type, name) DECLARE_BRANCH_VARIABLE(type, name)
@@ -141,7 +168,7 @@ namespace bbtautau {
 class AnaTupleWriter {
 public:
     using DataId = EventAnalyzerDataId;
-    using DataIdBiMap = boost::bimap<DataId, size_t>;
+    using NameMap = std::map<std::string, unsigned>;
     using DataIdMap = std::map<DataId, double>;
 
     struct CategoriesFlags {
@@ -162,14 +189,14 @@ public:
 
 private:
     static void FillUncWeightVec(const std::map<UncertaintyScale, float>& weights_in,
-                                 std::vector<float>& weights_out, bool store_relative = true);
+                                 float* weight, float* unc_up, float* unc_down);
 
 private:
     std::shared_ptr<TFile> file;
     AnaTuple tuple;
     AnaAuxTuple aux_tuple;
     bool runKinFit, runSVfit, allow_calc_svFit;
-    DataIdBiMap known_data_ids;
+    NameMap known_datasets, known_regions;
 };
 
 } // namespace bbtautau

--- a/Analysis/include/AnaTupleReader.h
+++ b/Analysis/include/AnaTupleReader.h
@@ -14,16 +14,16 @@ namespace bbtautau {
 class AnaTupleReader {
 public:
     using DataId = EventAnalyzerDataId;
-    using Hash = size_t;
-    using DataIdBiMap = boost::bimap<DataId, Hash>;
-    using DataIdMap = std::map<DataId, std::tuple<double, double>>;
+    using DatasetBiMap = boost::bimap<std::string, unsigned>;
+    using RegionBiMap = boost::bimap<EventRegion, unsigned>;
     using NameSet = std::set<std::string>;
     using RDF = ROOT::RDF::RNode;
 
     AnaTupleReader(const std::string& file_name, Channel channel, NameSet& active_var_names,
                    const std::vector<std::string>& input_friends, const EventTagCreator& event_tagger, const std::string& mdnn_version);
     size_t GetNumberOfEntries() const;
-    const DataId& GetDataIdByHash(Hash hash) const;
+    const std::string& GetDatasetByHash(unsigned hash) const;
+    const EventRegion& GetRegionByHash(unsigned hash) const;
     const RDF& GetDataFrame() const;
     const std::list<RDF>& GetSkimmedDataFrames() const;
     const std::map<std::string, std::set<std::string>>& GetParametricVariables() const;
@@ -43,7 +43,8 @@ private:
     ROOT::RDataFrame dataFrame;
     RDF df;
     std::list<RDF> skimmed_df;
-    DataIdBiMap known_data_ids;
+    DatasetBiMap known_datasets;
+    RegionBiMap known_regions;
     std::map<std::string, std::set<std::string>> parametric_vars;
     std::map<std::string, std::string> branch_types;
 };

--- a/Analysis/include/AnalysisCategories.h
+++ b/Analysis/include/AnalysisCategories.h
@@ -26,9 +26,10 @@ ENUM_NAMES(SampleType) = {
     { SampleType::TT, "TT" }, {SampleType::ggHH_NonRes, "ggHH_NonRes"},
     {SampleType::VBFHH_NonRes, "VBFHH_NonRes"}, {SampleType::ggHH_Res, "ggHH_Res"},
     {SampleType::VBFHH_Res, "VBFHH_Res"}
-
 };
-enum class DYFitModel { None = 0, NbjetBins = 1, NbjetBins_htBins = 2 , NbjetBins_NjetBins = 3, NbjetBins_ptBins = 4, Htt = 5};
+
+enum class DYFitModel { None = 0, NbjetBins = 1, NbjetBins_htBins = 2 , NbjetBins_NjetBins = 3, NbjetBins_ptBins = 4,
+                        Htt = 5};
 ENUM_NAMES(DYFitModel) = {
     { DYFitModel::None, "None" } , { DYFitModel::NbjetBins, "NbjetBins" } ,
     { DYFitModel::NbjetBins_htBins, "NbjetBins_htBins"}, { DYFitModel::NbjetBins_NjetBins, "NbjetBins_NjetBins"},
@@ -41,7 +42,6 @@ ENUM_NAMES(VBF_Category) = {
     { VBF_Category::ggHH, "ggHH"}, { VBF_Category::TT_L, "TT_L"},
     { VBF_Category::TT_FH, "TT_FH"}, { VBF_Category::ttH, "ttH"}, { VBF_Category::DY, "DY"}
 };
-
 
 struct EventRegion {
     static const EventRegion& Unknown();

--- a/Analysis/include/EventTags.h
+++ b/Analysis/include/EventTags.h
@@ -21,35 +21,29 @@ public:
     using DataId = EventTags::DataId;
 
     EventTagCreator(const EventCategorySet& _categories, const EventSubCategorySet& _subCategories,
-                     const std::map<SelectionCut, analysis::EllipseParameters>& _massWindowParams,
-                     const std::set<UncertaintySource>& _event_unc_sources,
-                     const std::set<UncertaintySource>& _norm_unc_sources,
-                     bool _use_IterativeFit,
-                     const Channel _channel, const Period _period);
+                    const std::set<UncertaintySource>& _event_unc_sources,
+                    const std::set<UncertaintySource>& _norm_unc_sources, bool _use_IterativeFit,
+                    Channel _channel, Period _period);
 
     static std::pair<float, VBF_Category> FindVBFCategory(float dnn_score_TT_dl, float dnn_score_TT_sl, float dnn_score_TT_lep,
                                                             float dnn_score_TT_FH, float dnn_score_DY, float dnn_score_ggHH,
                                                             float dnn_score_ttH, float dnn_score_ttH_tautau, float dnn_score_tth_bb,
                                                             float dnn_score_qqHH, float dnn_score_qqHH_vbf_c2v, float dnn_score_qqHH_sm);
 
-    EventTags CreateEventTags(const std::vector<DataId>& dataIds_base, const std::vector<float>& weights,
-                               const std::vector<float>& btag_weight_Loose,
-                               const std::vector<float>& btag_weight_Medium,
-                               const std::vector<float>& btag_weight_Tight,
-                               const std::vector<float>& btag_weight_IterativeFit,
-                               int num_central_jets, bool has_b_pair, int num_btag_loose, int num_btag_medium,
-                               int num_btag_tight, bool is_vbf, bool is_boosted, const std::pair<float, VBF_Category>& vbf_cat,
-                               const LorentzVectorM& SVfit_p4, const LorentzVectorM& MET_p4,
-                               float m_bb, float m_tt_vis, int kinFit_convergence, int SVfit_valid) const;
+    EventTags CreateEventTags(const DataId& dataId_base, float weight, bool is_data, float weight_btag_Loose,
+            float weight_btag_Medium, float weight_btag_Tight, float weight_btag_IterativeFit, int num_central_jets,
+            bool has_b_pair, int num_btag_loose, int num_btag_medium, int num_btag_tight, bool is_vbf, bool is_boosted,
+            const std::pair<float,VBF_Category>& vbf_cat, const LorentzVectorM& SVfit_p4, float m_bb, float m_tt_vis,
+            int kinFit_convergence, int SVfit_valid) const;
 
 private:
     const EventCategorySet& categories;
     const EventSubCategorySet& subCategories;
-    const std::map<SelectionCut,analysis::EllipseParameters>& massWindowParams;
     const std::set<UncertaintySource>& event_unc_sources, norm_unc_sources;
     const bool use_IterativeFit;
     const Channel channel;
     const Period period;
+    float iterativeFit_correction;
 };
 
 } // namespace bbtautau

--- a/Analysis/source/ProcessAnaTuple.cxx
+++ b/Analysis/source/ProcessAnaTuple.cxx
@@ -30,9 +30,10 @@ public:
 
     ProcessAnaTuple(const AnalyzerArguments& _args) :
         EventAnalyzerCore(_args, _args.channel(), false), args(_args), activeVariables(ParseVarSet(args.vars())),
-        eventTagger(ana_setup.categories, sub_categories_to_process, ana_setup.massWindowParams,
-                    ana_setup.unc_sources, {}, ana_setup.use_IterativeFit, args.channel(), args.period()),
-        tupleReader(args.input(), args.channel(), activeVariables, args.input_friends(), eventTagger, ana_setup.mdnn_version),
+        eventTagger(ana_setup.categories, sub_categories_to_process, ana_setup.unc_sources, {},
+                    ana_setup.use_IterativeFit, args.channel(), args.period()),
+        tupleReader(args.input(), args.channel(), activeVariables, args.input_friends(), eventTagger,
+                    ana_setup.mdnn_version),
         outputFile(root_ext::CreateRootFile(args.output() + "_full.root", ROOT::kLZMA, 9))
     {
         histConfig.Parse(FullPath(ana_setup.hist_cfg));
@@ -105,7 +106,7 @@ public:
 
         std::cout << "\tProcessing combined samples and QCD... " << std::endl;
         for(const auto& subCategory : subCategories) {
-
+            std::cout << "\t\tsub-category " << subCategory << "\n";
             ProcessCombinedSamples(anaDataCollection, subCategory, ana_setup.cmb_samples);
             for(const auto& sample : sample_descriptors) {
                 if(sample.second.sampleType == SampleType::QCD) {

--- a/Analysis/src/EventAnalyzerCore.cpp
+++ b/Analysis/src/EventAnalyzerCore.cpp
@@ -107,7 +107,7 @@ void EventAnalyzerCore::ProcessCombinedSamples(AnaDataCollection& anaDataCollect
             throw exception("Combined sample '%1%' not found.") % sample_name;
         CombinedSampleDescriptor& sample = cmb_sample_descriptors.at(sample_name);
         if(sample.channels.size() && !sample.channels.count(channelId)) continue;
-        std::cout << "\t\t" << sample.name << std::endl;
+        std::cout << "\t\t\t" << sample.name << '\n';
         for(const std::string& sub_sample_name : sample.sample_descriptors) {
             if(!sample_descriptors.count(sub_sample_name))
                 throw exception("Unable to create '%1%': sub-sample '%2%' not found.")

--- a/Analysis/src/EventTags.cpp
+++ b/Analysis/src/EventTags.cpp
@@ -8,20 +8,36 @@ namespace analysis {
 namespace bbtautau {
 
 EventTagCreator::EventTagCreator(const EventCategorySet& _categories, const EventSubCategorySet& _subCategories,
-                                  const std::map<SelectionCut, analysis::EllipseParameters>& _massWindowParams,
                                   const std::set<UncertaintySource>& _event_unc_sources,
                                   const std::set<UncertaintySource>& _norm_unc_sources,
-                                  bool _use_IterativeFit, const Channel _channel, const Period _period ):
-        categories(_categories), subCategories(_subCategories), massWindowParams(_massWindowParams),
-        event_unc_sources(_event_unc_sources), norm_unc_sources(_norm_unc_sources), use_IterativeFit(_use_IterativeFit),
-        channel(_channel),period(_period)
+                                  bool _use_IterativeFit, Channel _channel, Period _period) :
+        categories(_categories), subCategories(_subCategories), event_unc_sources(_event_unc_sources),
+        norm_unc_sources(_norm_unc_sources), use_IterativeFit(_use_IterativeFit), channel(_channel), period(_period)
 {
+    if(use_IterativeFit) {
+        static const std::map<std::pair<Channel, Period>, float> iterativeFit_corrections = {
+            {{Channel::ETau, Period::Run2016}, 1.0120}, // 1.01203715762
+            {{Channel::MuTau, Period::Run2016}, 1.013}, // 1.01296331792
+            {{Channel::TauTau, Period::Run2016}, 1.0101}, // 1.01010364517
+            {{Channel::ETau, Period::Run2017}, 0.9949}, // 0.994930642536
+            {{Channel::MuTau, Period::Run2017}, 0.9993}, // 0.999263715405
+            {{Channel::TauTau, Period::Run2017}, 0.9547}, // 0.954725518543
+            {{Channel::ETau, Period::Run2018}, 1.0004}, // 1.0003768284
+            {{Channel::MuTau, Period::Run2018}, 1.0039}, // 1.00388888346
+            {{Channel::TauTau, Period::Run2018}, 0.9795}, // 0.97949255088
+        };
+        auto iter = iterativeFit_corrections.find({channel, period});
+        if(iter == iterativeFit_corrections.end())
+            throw exception("Normalization correction for iterative fit is not available for %1% %2%")
+                    % period % channel;
+        iterativeFit_correction = iter->second;
+    }
 }
 
-std::pair<float, VBF_Category> EventTagCreator::FindVBFCategory(float dnn_score_TT_dl, float dnn_score_TT_sl, float dnn_score_TT_lep,
-                                                                 float dnn_score_TT_FH, float dnn_score_DY, float dnn_score_ggHH,
-                                                                 float dnn_score_ttH, float dnn_score_ttH_tautau, float dnn_score_tth_bb,
-                                                                 float dnn_score_qqHH, float dnn_score_qqHH_vbf_c2v, float dnn_score_qqHH_sm)
+std::pair<float, VBF_Category> EventTagCreator::FindVBFCategory(float dnn_score_TT_dl, float dnn_score_TT_sl,
+        float dnn_score_TT_lep, float dnn_score_TT_FH, float dnn_score_DY, float dnn_score_ggHH, float dnn_score_ttH,
+        float dnn_score_ttH_tautau, float dnn_score_tth_bb, float dnn_score_qqHH, float dnn_score_qqHH_vbf_c2v,
+        float dnn_score_qqHH_sm)
 {
     std::vector<std::pair<float, VBF_Category>> category_and_dnn = {
         { dnn_score_qqHH_sm + dnn_score_qqHH + dnn_score_qqHH_vbf_c2v, VBF_Category::qqHH },
@@ -30,91 +46,57 @@ std::pair<float, VBF_Category> EventTagCreator::FindVBFCategory(float dnn_score_
         { dnn_score_TT_FH, VBF_Category::TT_FH},
         { dnn_score_ttH + dnn_score_ttH_tautau + dnn_score_tth_bb, VBF_Category::ttH},
         { dnn_score_DY, VBF_Category::DY},
-        };
+    };
     return *std::max_element(category_and_dnn.begin(), category_and_dnn.end());
 }
 
-EventTags EventTagCreator::CreateEventTags(const std::vector<DataId>& dataIds_base,
-                                            const std::vector<float>& weights,
-                                            const std::vector<float>& btag_weight_Loose,
-                                            const std::vector<float>& btag_weight_Medium,
-                                            const std::vector<float>& btag_weight_Tight,
-                                            const std::vector<float>& btag_weight_IterativeFit,
-                                            int num_central_jets, bool has_b_pair,
-                                            int num_btag_loose, int num_btag_medium, int num_btag_tight,
-                                            bool is_vbf, bool is_boosted, const std::pair<float,VBF_Category>& vbf_cat,
-                                            const LorentzVectorM& SVfit_p4, const LorentzVectorM& MET_p4,
-                                            float m_bb, float m_tt_vis, int kinFit_convergence, int SVfit_valid) const
+EventTags EventTagCreator::CreateEventTags(const DataId& dataId_base, float weight, bool is_data,
+        float weight_btag_Loose, float weight_btag_Medium, float weight_btag_Tight, float weight_btag_IterativeFit,
+        int num_central_jets, bool has_b_pair, int num_btag_loose, int num_btag_medium, int num_btag_tight,
+        bool is_vbf, bool is_boosted, const std::pair<float,VBF_Category>& vbf_cat, const LorentzVectorM& SVfit_p4,
+        float m_bb, float /*m_tt_vis*/, int kinFit_convergence, int SVfit_valid) const
 {
-    static const EventCategory evtCategory_2j = EventCategory::Parse("2j");
-    const std::map<std::pair<Channel, Period>, float> iterativeFit_correction = {
-    {{Channel::ETau, Period::Run2016}, 1.0120}, // 1.01203715762
-    {{Channel::MuTau, Period::Run2016}, 1.013}, // 1.01296331792
-    {{Channel::TauTau, Period::Run2016}, 1.0101}, // 1.01010364517
-    {{Channel::ETau, Period::Run2017}, 0.9949}, // 0.994930642536
-    {{Channel::MuTau, Period::Run2017}, 0.9993}, // 0.999263715405
-    {{Channel::TauTau, Period::Run2017}, 0.9547}, // 0.954725518543
-    {{Channel::ETau, Period::Run2018}, 1.0004}, // 1.0003768284
-    {{Channel::MuTau, Period::Run2018}, 1.0039}, // 1.00388888346
-    {{Channel::TauTau, Period::Run2018}, 0.9795}, // 0.97949255088
-    };
     const std::map<DiscriminatorWP, size_t> bjet_counts = {
         { DiscriminatorWP::Loose, num_btag_loose },
         { DiscriminatorWP::Medium, num_btag_medium },
         { DiscriminatorWP::Tight, num_btag_tight}
     };
 
-    float iterativeFit_corr = iterativeFit_correction.at({channel, period});
-
-    std::map<DiscriminatorWP, float > btag_weights = {};
-    if((btag_weight_Loose.size()!=0 || btag_weight_Medium.size()!=0 || btag_weight_Tight.size()!=0) && !use_IterativeFit){
-        btag_weights = {
-            { DiscriminatorWP::Loose, btag_weight_Loose.at(0) },
-            { DiscriminatorWP::Medium, btag_weight_Medium.at(0) },
-            { DiscriminatorWP::Tight, btag_weight_Tight.at(0)},
-        };
-    }
-    else if(btag_weight_IterativeFit.size()!=0 && use_IterativeFit){
-        btag_weights = {
-            { DiscriminatorWP::Loose, btag_weight_IterativeFit.at(0)*iterativeFit_corr },
-            { DiscriminatorWP::Medium, btag_weight_IterativeFit.at(0)*iterativeFit_corr },
-            { DiscriminatorWP::Tight, btag_weight_IterativeFit.at(0)*iterativeFit_corr },
-        };
-    }
+    const std::map<DiscriminatorWP, float > btag_weights = {
+        { DiscriminatorWP::Loose, weight_btag_Loose },
+        { DiscriminatorWP::Medium, weight_btag_Medium },
+        { DiscriminatorWP::Tight, weight_btag_Tight },
+    };
+    const auto get_weight_btag = [&](DiscriminatorWP wp) {
+        if(use_IterativeFit) return weight_btag_IterativeFit * iterativeFit_correction;
+        return btag_weights.at(wp);
+    };
 
     EventTags evt_tags;
 
-    for (size_t i = 0; i < dataIds_base.size(); ++i) {
-        const auto& dataId_base = dataIds_base.at(i);
-        float weight = weights.at(i);
+    if(!event_unc_sources.count(dataId_base.Get<UncertaintySource>()))
+        return evt_tags;
 
-        if(dataId_base.Get<EventCategory>() != evtCategory_2j
-                || !event_unc_sources.count(dataId_base.Get<UncertaintySource>()))
+    for(const auto& category : categories) {
+        if(!category.Contains(static_cast<size_t>(num_central_jets), bjet_counts, is_vbf, is_boosted, vbf_cat.second))
             continue;
-
-        for(const auto& category : categories) {
-            if(!category.Contains(static_cast<size_t>(num_central_jets), bjet_counts, is_vbf, is_boosted, vbf_cat.second))
-                continue;
-            EventSubCategory evtSubCategory;
-            float btag_sf = 1;
-            if(category.HasBtagConstraint() && !btag_weights.empty()){
-                  btag_sf = btag_weights.at(category.BtagWP());
-            }
-            weight *= btag_sf;
+        EventSubCategory evtSubCategory;
+        const float btag_sf = category.HasBtagConstraint() && !is_data ? get_weight_btag(category.BtagWP()) : 1.f;
+        const float cat_weight = weight * btag_sf;
 
 
-            if(has_b_pair) {
-              const EllipseParameters& window = category.HasBoostConstraint() && category.IsBoosted() ? cuts::hh_bbtautau_Run2::hh_tag::boosted_window : cuts::hh_bbtautau_Run2::hh_tag::resolved_window;
-              evtSubCategory.SetCutResult(SelectionCut::mh, SVfit_valid && window.IsInside(SVfit_p4.M(), m_bb));
-              evtSubCategory.SetCutResult(SelectionCut::KinematicFitConverged, kinFit_convergence>0);
-            }
+        if(has_b_pair) {
+            const EllipseParameters& window = category.HasBoostConstraint() && category.IsBoosted()
+                    ? cuts::hh_bbtautau_Run2::hh_tag::boosted_window : cuts::hh_bbtautau_Run2::hh_tag::resolved_window;
+            evtSubCategory.SetCutResult(SelectionCut::mh, SVfit_valid && window.IsInside(SVfit_p4.M(), m_bb));
+            evtSubCategory.SetCutResult(SelectionCut::KinematicFitConverged, kinFit_convergence > 0);
+        }
 
-            for(const auto& subCategory : subCategories) {
-                if(!evtSubCategory.Implies(subCategory)) continue;
-                const auto& dataId = dataId_base.Set(category).Set(subCategory);
-                evt_tags.dataIds.push_back(dataId);
-                evt_tags.weights.push_back(weight);
-            }
+        for(const auto& subCategory : subCategories) {
+            if(!evtSubCategory.Implies(subCategory)) continue;
+            const auto& dataId = dataId_base.Set(category).Set(subCategory);
+            evt_tags.dataIds.push_back(dataId);
+            evt_tags.weights.push_back(cat_weight);
         }
     }
 

--- a/Analysis/test/EventCategories_t.cxx
+++ b/Analysis/test/EventCategories_t.cxx
@@ -11,6 +11,7 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 
 using EC = analysis::EventCategory;
 using WP = analysis::DiscriminatorWP;
+using VBF_Category = analysis::VBF_Category;
 
 BOOST_AUTO_TEST_CASE(ec_to_string)
 {
@@ -72,6 +73,11 @@ BOOST_AUTO_TEST_CASE(ec_to_string)
     {
         EC e(2,2,false, analysis::DiscriminatorWP::Medium, true, false);
         BOOST_TEST(EC::Parse("2j2b+B_noVBF") == e);
+    }
+
+    {
+        EC e(2,1,false, analysis::DiscriminatorWP::Medium, false, true, VBF_Category::ggHH);
+        BOOST_TEST(EC::Parse("2j1b+R_VBF_ggHH") == e);
     }
 
     {
@@ -138,6 +144,12 @@ BOOST_AUTO_TEST_CASE(ec_to_string)
         EC e(2,2,false, analysis::DiscriminatorWP::Medium, true, false);
         BOOST_TEST("2j2b+B_noVBF" == e.ToString());
     }
+
+    {
+        EC e(2,1,false, analysis::DiscriminatorWP::Medium, false, true, VBF_Category::ggHH);
+        BOOST_TEST("2j1b+R_VBF_ggHH" == e.ToString());
+    }
+
 }
 BOOST_AUTO_TEST_CASE(determine_ec_1)
 {

--- a/Instruments/source/ExtractBRegression.cxx
+++ b/Instruments/source/ExtractBRegression.cxx
@@ -44,7 +44,7 @@ public:
 
         bbtautau::AnaAuxTuple aux_tuple(inputFile.get(), true);
         aux_tuple.GetEntry(0);
-        refDataId = FindRefDataId(aux_tuple(), args.dataIdName());
+        refDataId = FindRefDatasetHash(aux_tuple(), args.dataIdName());
     }
 
     void Run()
@@ -119,14 +119,7 @@ public:
             anaTuple.GetEntry(n);
             const auto& event = anaTuple.data();
 
-            bool id_found = false;
-            for(size_t dataId : event.dataIds) {
-                if(dataId == refDataId) {
-                    id_found = true;
-                    break;
-                }
-            }
-            if(id_found) {
+            if(event.dataset == refDataId) {
 
                 #define BR(name, idx) b##idx##_##name = b##idx.name
                 #define B_FILL(idx) \
@@ -141,7 +134,7 @@ public:
                 #undef B_BR
                 #undef B_FILL
 
-                weight = event.all_weights.at(0);
+                weight = event.weight;
                 m_sv = event.SVfit_m;
                 tau1_pt = event.tau1_pt;
                 tau1_eta = event.tau1_eta;
@@ -267,15 +260,15 @@ public:
         throw exception("Jet entry not found. evt=%1%, eta=%2%, phi=%3%.") % evt % eta % phi;
     }
 
-    static size_t FindRefDataId(const bbtautau::AnaAux& aux, const std::string& name)
+    static unsigned FindRefDatasetHash(const bbtautau::AnaAux& aux, const std::string& name)
     {
-        const size_t N = aux.dataIds.size();
-        if(aux.dataId_names.size() != N)
+        const size_t N = aux.dataset_hashes.size();
+        if(aux.dataset_names.size() != N)
             throw exception("Inconsistent dataId info in AnaAux tuple.");
         for(size_t n = 0; n < N; ++n) {
-            const auto hash = aux.dataIds.at(n);
-            const auto& dataId_name = aux.dataId_names.at(n);
-            if(dataId_name == name)
+            const auto hash = aux.dataset_hashes.at(n);
+            const auto& dataset_name = aux.dataset_names.at(n);
+            if(dataset_name == name)
                 return hash;
         }
         throw exception("Hash not found.");


### PR DESCRIPTION
EventCategory:
- Switched to boost:regex to parse the string representation.
- Fixed bug introduced in the previous PR.

AnaTuple:
- Eliminated all vector branches.
- Store (dataset, region, unc_source, unc_scale) into separate branches instead of single dataIds
- Renamed weight-related branches